### PR TITLE
Add Golden Plains Shire Council

### DIFF
--- a/sa_local_councillor_popolo.json
+++ b/sa_local_councillor_popolo.json
@@ -8870,6 +8870,11 @@
       "classification": "legislature"
     },
     {
+      "id": "legislature/golden_plains_shire_council",
+      "name": "Golden Plains Shire Council",
+      "classification": "legislature"
+    },
+    {
       "id": "party/unknown",
       "name": "unknown",
       "classification": "party"
@@ -13930,36 +13935,43 @@
     },
     {
       "person_id": "helena_kirby",
+      "organization_id": "legislature/golden_plains_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
       "person_id": "nathan_hansford",
+      "organization_id": "legislature/golden_plains_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
       "person_id": "des_phelan",
+      "organization_id": "legislature/golden_plains_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
       "person_id": "jenny_blake",
+      "organization_id": "legislature/golden_plains_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
       "person_id": "bill_mcarthur",
+      "organization_id": "legislature/golden_plains_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
       "person_id": "andrew_cameron",
+      "organization_id": "legislature/golden_plains_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
       "person_id": "greg_vaughan",
+      "organization_id": "legislature/golden_plains_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     }

--- a/sa_local_councillor_popolo.json
+++ b/sa_local_councillor_popolo.json
@@ -8399,6 +8399,7 @@
       ]
     },
     {
+      "email": "cr.nhansford@gplains.vic.gov.au",
       "id": "nathan_hansford",
       "name": "Nathan Hansford",
       "sources": [


### PR DESCRIPTION
The Councillors for Golden Plains Shire didn't have their council listed. This was causing the PlanningAlerts importer the blow up I think.

This also adds the email for the one councillor who was missing it.