### PR TITLE
Add initial Tasmanian councillor data

### DIFF
--- a/tas_local_councillor_popolo.json
+++ b/tas_local_councillor_popolo.json
@@ -1,17 +1,3371 @@
 {
   "persons": [
-
+    {
+      "id": "break_o'day_council/janet_drummond",
+      "name": "Janet Drummond"
+    },
+    {
+      "id": "break_o'day_council/barry_le_fevre",
+      "name": "Barry Le Fevre"
+    },
+    {
+      "id": "break_o'day_council/john_mcgiveron",
+      "name": "John McGiveron"
+    },
+    {
+      "id": "break_o'day_council/glenn_mcguiness",
+      "name": "Glenn McGuiness"
+    },
+    {
+      "id": "break_o'day_council/margaret_osborne",
+      "name": "Margaret Osborne"
+    },
+    {
+      "id": "break_o'day_council/hannah_rubenach",
+      "name": "Hannah Rubenach"
+    },
+    {
+      "id": "break_o'day_council/john_tucker",
+      "name": "John Tucker"
+    },
+    {
+      "id": "break_o'day_council/mick_tucker",
+      "name": "Mick Tucker"
+    },
+    {
+      "id": "break_o'day_council/kylie_wright",
+      "name": "Kylie Wright"
+    },
+    {
+      "id": "brighton_council/barbara_curran",
+      "name": "Barbara Curran"
+    },
+    {
+      "id": "brighton_council/tony_foster",
+      "name": "Tony Foster"
+    },
+    {
+      "id": "brighton_council/wayne_garlick",
+      "name": "Wayne Garlick"
+    },
+    {
+      "id": "brighton_council/peter_geard",
+      "name": "Peter Geard"
+    },
+    {
+      "id": "brighton_council/leigh_gray",
+      "name": "Leigh Gray"
+    },
+    {
+      "id": "brighton_council/moya_jeffries",
+      "name": "Moya Jeffries"
+    },
+    {
+      "id": "brighton_council/phil_owen",
+      "name": "Phil Owen"
+    },
+    {
+      "id": "brighton_council/geoff_taylor",
+      "name": "Geoff Taylor"
+    },
+    {
+      "id": "brighton_council/sonya_williams",
+      "name": "Sonya Williams"
+    },
+    {
+      "id": "burnie_city_council/robert_bentley",
+      "name": "Robert Bentley"
+    },
+    {
+      "id": "burnie_city_council/ron_blake",
+      "name": "Ron Blake"
+    },
+    {
+      "id": "burnie_city_council/alvwyn_boyd",
+      "name": "Alvwyn Boyd"
+    },
+    {
+      "id": "burnie_city_council/teeny_brumby",
+      "name": "Teeny Brumby"
+    },
+    {
+      "id": "burnie_city_council/ken_dorsey",
+      "name": "Ken Dorsey"
+    },
+    {
+      "id": "burnie_city_council/anita_dow",
+      "name": "Anita Dow"
+    },
+    {
+      "id": "burnie_city_council/sandra_french",
+      "name": "Sandra French"
+    },
+    {
+      "id": "burnie_city_council/steven_kons",
+      "name": "Steven Kons"
+    },
+    {
+      "id": "burnie_city_council/chris_lynch",
+      "name": "Chris Lynch"
+    },
+    {
+      "id": "central_coast_council/john_bloomfield",
+      "name": "John Bloomfield"
+    },
+    {
+      "id": "central_coast_council/jan_bonde",
+      "name": "Jan Bonde"
+    },
+    {
+      "id": "central_coast_council/shane_broad",
+      "name": "Shane Broad"
+    },
+    {
+      "id": "central_coast_council/garry_carpenter",
+      "name": "Garry Carpenter"
+    },
+    {
+      "id": "central_coast_council/kath_downie",
+      "name": "Kath Downie"
+    },
+    {
+      "id": "central_coast_council/gerry_howard",
+      "name": "Gerry Howard"
+    },
+    {
+      "id": "central_coast_council/rowen_tongs",
+      "name": "Rowen Tongs"
+    },
+    {
+      "id": "central_coast_council/tony_van_rooyen",
+      "name": "Tony van Rooyen"
+    },
+    {
+      "id": "central_coast_council/phillip_viney",
+      "name": "Phillip Viney"
+    },
+    {
+      "id": "central_highlands_council/jim_allwright",
+      "name": "Jim Allwright"
+    },
+    {
+      "id": "central_highlands_council/tony_bailey",
+      "name": "Tony Bailey"
+    },
+    {
+      "id": "central_highlands_council/richard_bowden",
+      "name": "Richard Bowden"
+    },
+    {
+      "id": "central_highlands_council/robert_cassidy",
+      "name": "Robert Cassidy"
+    },
+    {
+      "id": "central_highlands_council/andrew_downie",
+      "name": "Andrew Downie"
+    },
+    {
+      "id": "central_highlands_council/evan_evans",
+      "name": "Evan Evans"
+    },
+    {
+      "id": "central_highlands_council/deirdre_flint",
+      "name": "Deirdre Flint"
+    },
+    {
+      "id": "central_highlands_council/erika_mcrae",
+      "name": "Erika McRae"
+    },
+    {
+      "id": "central_highlands_council/loueen_(lou)_triffitt",
+      "name": "Loueen (Lou) Triffitt"
+    },
+    {
+      "id": "circular_head_council/norman_berechree",
+      "name": "Norman Berechree"
+    },
+    {
+      "id": "circular_head_council/jan_bishop",
+      "name": "Jan Bishop"
+    },
+    {
+      "id": "circular_head_council/rod_hardy",
+      "name": "Rod Hardy"
+    },
+    {
+      "id": "circular_head_council/betty_kay",
+      "name": "Betty Kay"
+    },
+    {
+      "id": "circular_head_council/john_oldaker",
+      "name": "John Oldaker"
+    },
+    {
+      "id": "circular_head_council/ashley_popowski",
+      "name": "Ashley Popowski"
+    },
+    {
+      "id": "circular_head_council/nakore_popowski",
+      "name": "Nakore Popowski"
+    },
+    {
+      "id": "circular_head_council/daryl_quilliam",
+      "name": "Daryl Quilliam"
+    },
+    {
+      "id": "circular_head_council/trevor_spinks",
+      "name": "Trevor Spinks"
+    },
+    {
+      "email": "ald_jcampbell@ccc.tas.gov.au",
+      "id": "clarence_city_council/jock_campbell",
+      "image": "http://www.ccc.tas.gov.au/webdata/resources/contact/campbell.jpg",
+      "name": "Jock Campbell",
+      "images": [
+        {
+          "url": "http://www.ccc.tas.gov.au/webdata/resources/contact/campbell.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.ccc.tas.gov.au/page.aspx?u=1150"
+        }
+      ]
+    },
+    {
+      "email": "mayor@ccc.tas.gov.au",
+      "id": "clarence_city_council/doug_chipman",
+      "image": "http://www.ccc.tas.gov.au/webdata/resources/contact/chipman2.jpg",
+      "name": "Doug Chipman",
+      "images": [
+        {
+          "url": "http://www.ccc.tas.gov.au/webdata/resources/contact/chipman2.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.ccc.tas.gov.au/page.aspx?u=1148"
+        }
+      ]
+    },
+    {
+      "email": "ald_hchong@ccc.tas.gov.au",
+      "id": "clarence_city_council/heather_chong",
+      "image": "http://www.ccc.tas.gov.au/webdata/resources/contact/Ald_Chong_Colour_Web.jpg",
+      "name": "Heather Chong",
+      "images": [
+        {
+          "url": "http://www.ccc.tas.gov.au/webdata/resources/contact/Ald_Chong_Colour_Web.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.ccc.tas.gov.au/page.aspx?u=1149"
+        }
+      ]
+    },
+    {
+      "email": "ald_pcusick@ccc.tas.gov.au",
+      "id": "clarence_city_council/peter_cusick",
+      "image": "http://www.ccc.tas.gov.au/webdata/resources/contact/Ald.Cusick.jpg",
+      "name": "Peter Cusick",
+      "images": [
+        {
+          "url": "http://www.ccc.tas.gov.au/webdata/resources/contact/Ald.Cusick.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.ccc.tas.gov.au/page.aspx?u=1809"
+        }
+      ]
+    },
+    {
+      "email": "ald_ddoust@ccc.tas.gov.au",
+      "id": "clarence_city_council/doug_doust",
+      "image": "http://www.ccc.tas.gov.au/webdata/resources/contact/Ald_Doust_DSC0217.jpg",
+      "name": "Doug Doust",
+      "images": [
+        {
+          "url": "http://www.ccc.tas.gov.au/webdata/resources/contact/Ald_Doust_DSC0217.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.ccc.tas.gov.au/page.aspx?u=1610"
+        }
+      ]
+    },
+    {
+      "email": "ald_dhulme@ccc.tas.gov.au",
+      "id": "clarence_city_council/daniel_hulme",
+      "image": "http://www.ccc.tas.gov.au/webdata/resources/contact/Ald.Hulme.jpg",
+      "name": "Daniel Hulme",
+      "images": [
+        {
+          "url": "http://www.ccc.tas.gov.au/webdata/resources/contact/Ald.Hulme.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.ccc.tas.gov.au/page.aspx?u=1810"
+        }
+      ]
+    },
+    {
+      "email": "rjames@trump.net.au",
+      "id": "clarence_city_council/richard_james",
+      "image": "http://www.ccc.tas.gov.au/webdata/resources/contact/james.jpg",
+      "name": "Richard James",
+      "images": [
+        {
+          "url": "http://www.ccc.tas.gov.au/webdata/resources/contact/james.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.ccc.tas.gov.au/page.aspx?u=1155"
+        }
+      ]
+    },
+    {
+      "email": "ald.kmcfarlane@gmail.com",
+      "id": "clarence_city_council/kay_mcfarlane",
+      "image": "http://www.ccc.tas.gov.au/webdata/resources/contact/mcfarlane1.jpg",
+      "name": "Kay McFarlane",
+      "images": [
+        {
+          "url": "http://www.ccc.tas.gov.au/webdata/resources/contact/mcfarlane1.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.ccc.tas.gov.au/page.aspx?u=1152"
+        }
+      ]
+    },
+    {
+      "email": "peersccc@netspace.net.au",
+      "id": "clarence_city_council/jonn_peers",
+      "image": "http://www.ccc.tas.gov.au/webdata/resources/contact/peers.jpg",
+      "name": "Jonn Peers",
+      "images": [
+        {
+          "url": "http://www.ccc.tas.gov.au/webdata/resources/contact/peers.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.ccc.tas.gov.au/page.aspx?u=1151"
+        }
+      ]
+    },
+    {
+      "email": "ald_dthurley@ccc.tas.gov.au",
+      "id": "clarence_city_council/debra_thurley",
+      "image": "http://www.ccc.tas.gov.au/webdata/resources/contact/Ald.Thurley2.jpg",
+      "name": "Debra Thurley",
+      "images": [
+        {
+          "url": "http://www.ccc.tas.gov.au/webdata/resources/contact/Ald.Thurley2.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.ccc.tas.gov.au/thurley"
+        }
+      ]
+    },
+    {
+      "email": "ald_svonbertouch@ccc.tas.gov.au",
+      "id": "clarence_city_council/sharyn_von_bertouch",
+      "image": "http://www.ccc.tas.gov.au/webdata/resources/contact/Ald_von-Bertouch_Colour_Web.jpg",
+      "name": "Sharyn Von Bertouch",
+      "images": [
+        {
+          "url": "http://www.ccc.tas.gov.au/webdata/resources/contact/Ald_von-Bertouch_Colour_Web.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.ccc.tas.gov.au/page.aspx?u=1156"
+        }
+      ]
+    },
+    {
+      "email": "ald_jwalker@ccc.tas.gov.au",
+      "id": "clarence_city_council/james_walker",
+      "image": "http://www.ccc.tas.gov.au/webdata/resources/contact/Ald_Walker.jpg",
+      "name": "James Walker",
+      "images": [
+        {
+          "url": "http://www.ccc.tas.gov.au/webdata/resources/contact/Ald_Walker.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.ccc.tas.gov.au/page.aspx?u=1633"
+        }
+      ]
+    },
+    {
+      "id": "derwent_valley_council/paul_belcher",
+      "name": "Paul Belcher"
+    },
+    {
+      "id": "derwent_valley_council/damian_bester",
+      "name": "Damian Bester"
+    },
+    {
+      "id": "derwent_valley_council/martyn_evans",
+      "name": "Martyn Evans"
+    },
+    {
+      "id": "derwent_valley_council/james_graham",
+      "name": "James Graham"
+    },
+    {
+      "id": "derwent_valley_council/barry_lathey",
+      "name": "Barry Lathey"
+    },
+    {
+      "id": "derwent_valley_council/frank_pearce",
+      "name": "Frank Pearce"
+    },
+    {
+      "id": "derwent_valley_council/ben_shaw",
+      "name": "Ben Shaw"
+    },
+    {
+      "id": "derwent_valley_council/julie_triffett",
+      "name": "Julie Triffett"
+    },
+    {
+      "id": "devonport_city_council/charlie_emmerton",
+      "name": "Charlie Emmerton"
+    },
+    {
+      "id": "devonport_city_council/grant_goodwin",
+      "name": "Grant Goodwin"
+    },
+    {
+      "id": "devonport_city_council/alison_jarman",
+      "name": "Alison Jarman"
+    },
+    {
+      "id": "devonport_city_council/justine_keay",
+      "name": "Justine Keay"
+    },
+    {
+      "id": "devonport_city_council/lynn_laycock",
+      "name": "Lynn Laycock"
+    },
+    {
+      "id": "devonport_city_council/jeff_matthews",
+      "name": "Jeff Matthews"
+    },
+    {
+      "id": "devonport_city_council/steve_martin",
+      "name": "Steve Martin"
+    },
+    {
+      "id": "devonport_city_council/leon_perry",
+      "name": "Leon Perry"
+    },
+    {
+      "id": "devonport_city_council/annette_rockliff",
+      "name": "Annette Rockliff"
+    },
+    {
+      "id": "dorset_council/lawrence_archer",
+      "name": "Lawrence Archer"
+    },
+    {
+      "id": "dorset_council/steven_arnold",
+      "name": "Steven Arnold"
+    },
+    {
+      "id": "dorset_council/maxwell_hall",
+      "name": "Maxwell Hall"
+    },
+    {
+      "id": "dorset_council/greg_howard",
+      "name": "Greg Howard"
+    },
+    {
+      "id": "dorset_council/dale_jessup",
+      "name": "Dale Jessup"
+    },
+    {
+      "id": "dorset_council/sheryl_martin",
+      "name": "Sheryl Martin"
+    },
+    {
+      "id": "dorset_council/shaun_moore",
+      "name": "Shaun Moore"
+    },
+    {
+      "id": "dorset_council/leon_quilliam",
+      "name": "Leon Quilliam"
+    },
+    {
+      "id": "dorset_council/leonie_stein",
+      "name": "Leonie Stein"
+    },
+    {
+      "id": "flinders_council/marc_cobham",
+      "name": "Marc Cobham"
+    },
+    {
+      "id": "flinders_council/carol_cox",
+      "name": "Carol Cox"
+    },
+    {
+      "id": "flinders_council/chris_rhodes",
+      "name": "Chris Rhodes"
+    },
+    {
+      "id": "flinders_council/peter_rhodes",
+      "name": "Peter Rhodes"
+    },
+    {
+      "id": "flinders_council/ken_stockton",
+      "name": "Ken Stockton"
+    },
+    {
+      "id": "flinders_council/david_williams",
+      "name": "David Williams"
+    },
+    {
+      "id": "flinders_council/gerald_willis",
+      "name": "Gerald Willis"
+    },
+    {
+      "id": "george_town_council/bridget_archer",
+      "name": "Bridget Archer"
+    },
+    {
+      "id": "george_town_council/heather_barwick",
+      "name": "Heather Barwick"
+    },
+    {
+      "id": "george_town_council/doug_burt",
+      "name": "Doug Burt"
+    },
+    {
+      "id": "george_town_council/greg_dawson",
+      "name": "Greg Dawson"
+    },
+    {
+      "id": "george_town_council/john_glisson",
+      "name": "John Glisson"
+    },
+    {
+      "id": "george_town_council/tim_harris",
+      "name": "Tim Harris"
+    },
+    {
+      "id": "george_town_council/richard_nicholls",
+      "name": "Richard Nicholls"
+    },
+    {
+      "id": "george_town_council/tim_parish",
+      "name": "Tim Parish"
+    },
+    {
+      "id": "george_town_council/peter_parkes",
+      "name": "Peter Parkes"
+    },
+    {
+      "id": "glamorgan-spring_bay_council/cheryl_arnol",
+      "name": "Cheryl Arnol"
+    },
+    {
+      "id": "glamorgan-spring_bay_council/bertrand_cadart",
+      "name": "Bertrand Cadart"
+    },
+    {
+      "id": "glamorgan-spring_bay_council/jenifer_crawford",
+      "name": "Jenifer Crawford"
+    },
+    {
+      "id": "glamorgan-spring_bay_council/michael_kent",
+      "name": "Michael Kent"
+    },
+    {
+      "id": "glamorgan-spring_bay_council/greg_raspin",
+      "name": "Greg Raspin"
+    },
+    {
+      "id": "glamorgan-spring_bay_council/britt_steiner",
+      "name": "Britt Steiner"
+    },
+    {
+      "id": "glamorgan-spring_bay_council/debbie_wisby",
+      "name": "Debbie Wisby"
+    },
+    {
+      "id": "glamorgan-spring_bay_council/jenny_woods",
+      "name": "Jenny Woods"
+    },
+    {
+      "id": "glenorchy_city_council/jennifer_branch-allen",
+      "name": "Jennifer Branch-Allen"
+    },
+    {
+      "id": "glenorchy_city_council/jan_dunsby",
+      "name": "Jan Dunsby"
+    },
+    {
+      "id": "glenorchy_city_council/kristie_johnston",
+      "name": "Kristie Johnston"
+    },
+    {
+      "id": "glenorchy_city_council/steven_king",
+      "name": "Steven King"
+    },
+    {
+      "id": "glenorchy_city_council/christine_lucas",
+      "name": "Christine Lucas"
+    },
+    {
+      "id": "glenorchy_city_council/haydyn_nielsen",
+      "name": "Haydyn Nielsen"
+    },
+    {
+      "id": "glenorchy_city_council/david_pearce",
+      "name": "David Pearce"
+    },
+    {
+      "id": "glenorchy_city_council/harry_quick",
+      "name": "Harry Quick"
+    },
+    {
+      "id": "glenorchy_city_council/stuart_slade",
+      "name": "Stuart Slade"
+    },
+    {
+      "id": "glenorchy_city_council/matt_stevenson",
+      "name": "Matt Stevenson"
+    },
+    {
+      "id": "hobart_city_council/jeff_briscoe",
+      "name": "Jeff Briscoe"
+    },
+    {
+      "id": "hobart_city_council/helen_burnet",
+      "name": "Helen Burnet"
+    },
+    {
+      "id": "hobart_city_council/ron_christie",
+      "name": "Ron Christie"
+    },
+    {
+      "id": "hobart_city_council/philip_cocker",
+      "name": "Philip Cocker"
+    },
+    {
+      "id": "hobart_city_council/suzy_cooper",
+      "name": "Suzy Cooper"
+    },
+    {
+      "id": "hobart_city_council/tania_denison",
+      "name": "Tania Denison"
+    },
+    {
+      "id": "hobart_city_council/sue_hickey",
+      "name": "Sue Hickey"
+    },
+    {
+      "id": "hobart_city_council/anna_reynolds",
+      "name": "Anna Reynolds"
+    },
+    {
+      "id": "hobart_city_council/eva_ruzicka",
+      "name": "Eva Ruzicka"
+    },
+    {
+      "id": "hobart_city_council/peter_sexton",
+      "name": "Peter Sexton"
+    },
+    {
+      "id": "hobart_city_council/damon_thomas",
+      "name": "Damon Thomas"
+    },
+    {
+      "id": "hobart_city_council/marti_zucco",
+      "name": "Marti Zucco"
+    },
+    {
+      "id": "huon_valley_council/peter_coad",
+      "name": "Peter Coad"
+    },
+    {
+      "id": "huon_valley_council/lydia_eastley",
+      "name": "Lydia Eastley"
+    },
+    {
+      "id": "huon_valley_council/bruce_heron",
+      "name": "Bruce Heron"
+    },
+    {
+      "id": "huon_valley_council/ian_mackintosh",
+      "name": "Ian Mackintosh"
+    },
+    {
+      "id": "huon_valley_council/ian_paul",
+      "name": "Ian Paul"
+    },
+    {
+      "id": "huon_valley_council/pavel_ruzicka",
+      "name": "Pavel Ruzicka"
+    },
+    {
+      "id": "huon_valley_council/liz_smith",
+      "name": "Liz Smith"
+    },
+    {
+      "id": "huon_valley_council/ken_studley",
+      "name": "Ken Studley"
+    },
+    {
+      "id": "huon_valley_council/mike_wilson",
+      "name": "Mike Wilson"
+    },
+    {
+      "id": "kentish_council/rodney_blenkhorn",
+      "name": "Rodney Blenkhorn"
+    },
+    {
+      "id": "kentish_council/linda_cassidy",
+      "name": "Linda Cassidy"
+    },
+    {
+      "id": "kentish_council/kate_haberle",
+      "name": "Kate Haberle"
+    },
+    {
+      "id": "kentish_council/terry_hughes",
+      "name": "Terry Hughes"
+    },
+    {
+      "id": "kentish_council/penny_lane",
+      "name": "Penny Lane"
+    },
+    {
+      "id": "kentish_council/phillip_richards",
+      "name": "Phillip Richards"
+    },
+    {
+      "id": "kentish_council/don_thwaites",
+      "name": "Don Thwaites"
+    },
+    {
+      "id": "kentish_council/annie_willcock",
+      "name": "Annie Willcock"
+    },
+    {
+      "id": "kentish_council/tim_wilson",
+      "name": "Tim Wilson"
+    },
+    {
+      "id": "king_island_council/jim_benn",
+      "name": "Jim Benn"
+    },
+    {
+      "id": "king_island_council/david_bowling",
+      "name": "David Bowling"
+    },
+    {
+      "id": "king_island_council/douglas_collins",
+      "name": "Douglas Collins"
+    },
+    {
+      "id": "king_island_council/royce_conley",
+      "name": "Royce Conley"
+    },
+    {
+      "id": "king_island_council/jim_cooper",
+      "name": "Jim Cooper"
+    },
+    {
+      "id": "king_island_council/sally_haneveer",
+      "name": "Sally Haneveer"
+    },
+    {
+      "id": "king_island_council/duncan_mcfie",
+      "name": "Duncan McFie"
+    },
+    {
+      "id": "king_island_council/david_munday",
+      "name": "David Munday"
+    },
+    {
+      "id": "king_island_council/kirsty_russell",
+      "name": "Kirsty Russell"
+    },
+    {
+      "id": "kingborough_council/richard_atkinson",
+      "name": "Richard Atkinson"
+    },
+    {
+      "id": "kingborough_council/sue_bastone",
+      "name": "Sue Bastone"
+    },
+    {
+      "id": "kingborough_council/graham_bury",
+      "name": "Graham Bury"
+    },
+    {
+      "id": "kingborough_council/flora_fox",
+      "name": "Flora Fox"
+    },
+    {
+      "id": "kingborough_council/david_grace",
+      "name": "David Grace"
+    },
+    {
+      "id": "kingborough_council/michael_percey",
+      "name": "Michael Percey"
+    },
+    {
+      "id": "kingborough_council/nic_street",
+      "name": "Nic Street"
+    },
+    {
+      "id": "kingborough_council/steve_wass",
+      "name": "Steve Wass"
+    },
+    {
+      "id": "kingborough_council/dean_winter",
+      "name": "Dean Winter"
+    },
+    {
+      "id": "kingborough_council/paula_wriedt",
+      "name": "Paula Wriedt"
+    },
+    {
+      "id": "latrobe_council/graeme_brown",
+      "name": "Graeme Brown"
+    },
+    {
+      "id": "latrobe_council/dayna_dennison",
+      "name": "Dayna Dennison"
+    },
+    {
+      "id": "latrobe_council/peter_freshney",
+      "name": "Peter Freshney"
+    },
+    {
+      "id": "latrobe_council/mike_mclaren",
+      "name": "Mike McLaren"
+    },
+    {
+      "id": "latrobe_council/john_perkins",
+      "name": "John Perkins"
+    },
+    {
+      "id": "latrobe_council/rick_rockliff",
+      "name": "Rick Rockliff"
+    },
+    {
+      "id": "latrobe_council/garry_sims",
+      "name": "Garry Sims"
+    },
+    {
+      "id": "latrobe_council/gerrad_wicks",
+      "name": "Gerrad Wicks"
+    },
+    {
+      "id": "latrobe_council/lesley_young",
+      "name": "Lesley Young"
+    },
+    {
+      "email": "Darren.Alexander@launceston.tas.gov.au",
+      "id": "launceston_city_council/darren_alexander",
+      "image": "http://www.launceston.tas.gov.au/upfiles/lcc/cont/_council/council/mayor_and_alderman/darren_web_2014.jpg",
+      "name": "Darren Alexander",
+      "images": [
+        {
+          "url": "http://www.launceston.tas.gov.au/upfiles/lcc/cont/_council/council/mayor_and_alderman/darren_web_2014.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.launceston.tas.gov.au/lcc/index.php?c=10"
+        }
+      ]
+    },
+    {
+      "email": "Jimc7@bigpond.com",
+      "id": "launceston_city_council/jim_cox",
+      "image": "http://www.launceston.tas.gov.au/upfiles/lcc/cont/_council/council/mayor_and_alderman/jim_web_2014.jpg",
+      "name": "Jim Cox",
+      "images": [
+        {
+          "url": "http://www.launceston.tas.gov.au/upfiles/lcc/cont/_council/council/mayor_and_alderman/jim_web_2014.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.launceston.tas.gov.au/lcc/index.php?c=10"
+        }
+      ]
+    },
+    {
+      "email": "Janie.Finlay@launceston.tas.gov.au",
+      "id": "launceston_city_council/janie_finlay",
+      "image": "http://www.launceston.tas.gov.au/upfiles/lcc/cont/_council/council/mayor_and_alderman/janie_web_2014.jpg",
+      "name": "Janie Finlay",
+      "images": [
+        {
+          "url": "http://www.launceston.tas.gov.au/upfiles/lcc/cont/_council/council/mayor_and_alderman/janie_web_2014.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.launceston.tas.gov.au/lcc/index.php?c=10"
+        }
+      ]
+    },
+    {
+      "email": "Danny.Gibson@launceston.tas.gov.au",
+      "id": "launceston_city_council/danny_gibson",
+      "image": "http://www.launceston.tas.gov.au/upfiles/lcc/cont/_council/council/mayor_and_alderman/danny_web_2014.jpg",
+      "name": "Danny Gibson",
+      "images": [
+        {
+          "url": "http://www.launceston.tas.gov.au/upfiles/lcc/cont/_council/council/mayor_and_alderman/danny_web_2014.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.launceston.tas.gov.au/lcc/index.php?c=10"
+        }
+      ]
+    },
+    {
+      "email": "r.dougal@bigpond.net.au",
+      "id": "launceston_city_council/robin_mckendrick",
+      "image": "http://www.launceston.tas.gov.au/upfiles/lcc/cont/_council/council/mayor_and_alderman/robin_web_2014.jpg",
+      "name": "Robin McKendrick",
+      "images": [
+        {
+          "url": "http://www.launceston.tas.gov.au/upfiles/lcc/cont/_council/council/mayor_and_alderman/robin_web_2014.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.launceston.tas.gov.au/lcc/index.php?c=10"
+        }
+      ]
+    },
+    {
+      "email": "dhmckenzie@kpmg.com.au",
+      "id": "launceston_city_council/hugh_mckenzie",
+      "image": "http://www.launceston.tas.gov.au/upfiles/lcc/cont/_council/council/mayor_and_alderman/hugh_web_2014.jpg",
+      "name": "Hugh McKenzie",
+      "images": [
+        {
+          "url": "http://www.launceston.tas.gov.au/upfiles/lcc/cont/_council/council/mayor_and_alderman/hugh_web_2014.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.launceston.tas.gov.au/lcc/index.php?c=10"
+        }
+      ]
+    },
+    {
+      "email": "Ted.Sands@launceston.tas.gov.au",
+      "id": "launceston_city_council/ted_sands",
+      "image": "http://www.launceston.tas.gov.au/upfiles/lcc/cont/_council/council/mayor_and_alderman/ted_web_2014jpg.jpg",
+      "name": "Ted Sands",
+      "images": [
+        {
+          "url": "http://www.launceston.tas.gov.au/upfiles/lcc/cont/_council/council/mayor_and_alderman/ted_web_2014jpg.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.launceston.tas.gov.au/lcc/index.php?c=10"
+        }
+      ]
+    },
+    {
+      "email": "risoward@hotmail.com",
+      "id": "launceston_city_council/rob_soward",
+      "image": "http://www.launceston.tas.gov.au/upfiles/lcc/cont/_council/council/mayor_and_alderman/rob_web_2014.jpg",
+      "name": "Rob Soward",
+      "images": [
+        {
+          "url": "http://www.launceston.tas.gov.au/upfiles/lcc/cont/_council/council/mayor_and_alderman/rob_web_2014.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.launceston.tas.gov.au/lcc/index.php?c=10"
+        }
+      ]
+    },
+    {
+      "email": "Karina.Stojansek@launceston.tas.gov.au",
+      "id": "launceston_city_council/karina_stojansek",
+      "image": "http://www.nda.com.au/Photos/Karina.jpg",
+      "name": "Karina Stojansek",
+      "images": [
+        {
+          "url": "http://www.nda.com.au/Photos/Karina.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.launceston.tas.gov.au/lcc/index.php?c=10"
+        }
+      ]
+    },
+    {
+      "email": "mayor@launceston.tas.gov.au",
+      "id": "launceston_city_council/albert_van_zetten",
+      "image": "http://www.launceston.tas.gov.au/upfiles/lcc/cont/_council/council/mayor_and_alderman/albert_web_2014.jpg",
+      "name": "Albert van Zetten",
+      "images": [
+        {
+          "url": "http://www.launceston.tas.gov.au/upfiles/lcc/cont/_council/council/mayor_and_alderman/albert_web_2014.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.launceston.tas.gov.au/lcc/index.php?c=10"
+        }
+      ]
+    },
+    {
+      "email": "Emma.Williams@launceston.tas.gov.au",
+      "id": "launceston_city_council/emma_williams",
+      "image": "http://www.launceston.tas.gov.au/upfiles/lcc/cont/_council/council/mayor_and_alderman/emma_web_2014.jpg",
+      "name": "Emma Williams",
+      "images": [
+        {
+          "url": "http://www.launceston.tas.gov.au/upfiles/lcc/cont/_council/council/mayor_and_alderman/emma_web_2014.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.launceston.tas.gov.au/lcc/index.php?c=10"
+        }
+      ]
+    },
+    {
+      "email": "Simon.Wood@launceston.tas.gov.au",
+      "id": "launceston_city_council/simon_wood",
+      "image": "http://www.launceston.tas.gov.au/upfiles/lcc/cont/_council/council/mayor_and_alderman/simon_web_2014.jpg",
+      "name": "Simon Wood",
+      "images": [
+        {
+          "url": "http://www.launceston.tas.gov.au/upfiles/lcc/cont/_council/council/mayor_and_alderman/simon_web_2014.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.launceston.tas.gov.au/lcc/index.php?c=10"
+        }
+      ]
+    },
+    {
+      "id": "meander_valley_council/andrew_connor",
+      "name": "Andrew Connor"
+    },
+    {
+      "id": "meander_valley_council/michael_kelly",
+      "name": "Michael Kelly"
+    },
+    {
+      "id": "meander_valley_council/tanya_king",
+      "name": "Tanya King"
+    },
+    {
+      "id": "meander_valley_council/ian_mackenzie",
+      "name": "Ian Mackenzie"
+    },
+    {
+      "id": "meander_valley_council/craig_perkins",
+      "name": "Craig Perkins"
+    },
+    {
+      "id": "meander_valley_council/bob_richardson",
+      "name": "Bob Richardson"
+    },
+    {
+      "id": "meander_valley_council/rodney_synfield",
+      "name": "Rodney Synfield"
+    },
+    {
+      "id": "meander_valley_council/deborah_white",
+      "name": "Deborah White"
+    },
+    {
+      "id": "meander_valley_council/rodney_youd",
+      "name": "Rodney Youd"
+    },
+    {
+      "id": "northern_midlands_council/dick_adams",
+      "name": "Dick Adams"
+    },
+    {
+      "id": "northern_midlands_council/andrew_calvert",
+      "name": "Andrew Calvert"
+    },
+    {
+      "id": "northern_midlands_council/david_downie",
+      "name": "David Downie"
+    },
+    {
+      "id": "northern_midlands_council/ian_goninon",
+      "name": "Ian Goninon"
+    },
+    {
+      "id": "northern_midlands_council/leisa_gordon",
+      "name": "Leisa Gordon"
+    },
+    {
+      "id": "northern_midlands_council/richard_goss",
+      "name": "Richard Goss"
+    },
+    {
+      "id": "northern_midlands_council/mary_knowles",
+      "name": "Mary Knowles"
+    },
+    {
+      "id": "northern_midlands_council/janet_lambert",
+      "name": "Janet Lambert"
+    },
+    {
+      "id": "northern_midlands_council/michael_polley",
+      "name": "Michael Polley"
+    },
+    {
+      "id": "sorell_council/deborah_de_williams",
+      "name": "Deborah De Williams"
+    },
+    {
+      "id": "sorell_council/kerry_degrassi",
+      "name": "Kerry Degrassi"
+    },
+    {
+      "id": "sorell_council/graeme_evans",
+      "name": "Graeme Evans"
+    },
+    {
+      "id": "sorell_council/vlad_gala",
+      "name": "Vlad Gala"
+    },
+    {
+      "id": "sorell_council/brett_mcdonald",
+      "name": "Brett McDonald"
+    },
+    {
+      "id": "sorell_council/natham_reynolds",
+      "name": "Natham Reynolds"
+    },
+    {
+      "id": "sorell_council/carmel_torenius",
+      "name": "Carmel Torenius"
+    },
+    {
+      "id": "sorell_council/kerry_vincent",
+      "name": "Kerry Vincent"
+    },
+    {
+      "id": "sorell_council/lindsay_white",
+      "name": "Lindsay White"
+    },
+    {
+      "id": "southern_midlands_council/tony_bantick",
+      "name": "Tony Bantick"
+    },
+    {
+      "id": "southern_midlands_council/edwin_batt",
+      "name": "Edwin Batt"
+    },
+    {
+      "id": "southern_midlands_council/tony_bisdee",
+      "name": "Tony Bisdee"
+    },
+    {
+      "id": "southern_midlands_council/bob_campbell",
+      "name": "Bob Campbell"
+    },
+    {
+      "id": "southern_midlands_council/donald_fish",
+      "name": "Donald Fish"
+    },
+    {
+      "id": "southern_midlands_council/alex_green",
+      "name": "Alex Green"
+    },
+    {
+      "id": "southern_midlands_council/mark_jones",
+      "name": "Mark Jones"
+    },
+    {
+      "id": "tasman_council/pam_fenerty",
+      "name": "Pam Fenerty"
+    },
+    {
+      "id": "tasman_council/roseanne_heyward",
+      "name": "Roseanne Heyward"
+    },
+    {
+      "id": "tasman_council/alan_hull",
+      "name": "Alan Hull"
+    },
+    {
+      "id": "tasman_council/roger_larner",
+      "name": "Roger Larner"
+    },
+    {
+      "id": "tasman_council/david_macdonald",
+      "name": "David Macdonald"
+    },
+    {
+      "id": "tasman_council/kelly_spaulding",
+      "name": "Kelly Spaulding"
+    },
+    {
+      "id": "tasman_council/maria_stacey",
+      "name": "Maria Stacey"
+    },
+    {
+      "id": "waratah-wynyard_council/maureen_bradley",
+      "name": "Maureen Bradley"
+    },
+    {
+      "id": "waratah-wynyard_council/gary_bramich",
+      "name": "Gary Bramich"
+    },
+    {
+      "id": "waratah-wynyard_council/mary_duniam",
+      "name": "Mary Duniam"
+    },
+    {
+      "id": "waratah-wynyard_council/darren_fairbrother",
+      "name": "Darren Fairbrother"
+    },
+    {
+      "id": "waratah-wynyard_council/alwyn_friedersdorff",
+      "name": "Alwyn Friedersdorff"
+    },
+    {
+      "id": "waratah-wynyard_council/kevin_hyland",
+      "name": "Kevin Hyland"
+    },
+    {
+      "id": "waratah-wynyard_council/robert_walsh",
+      "name": "Robert Walsh"
+    },
+    {
+      "id": "waratah-wynyard_council/stephen_wright",
+      "name": "Stephen Wright"
+    },
+    {
+      "id": "west_coast_council/robyn_gerrity",
+      "name": "Robyn Gerrity"
+    },
+    {
+      "id": "west_coast_council/al_medwin",
+      "name": "Al Medwin"
+    },
+    {
+      "id": "west_coast_council/lindsay_newman",
+      "name": "Lindsay Newman"
+    },
+    {
+      "id": "west_coast_council/lyn_o'grady",
+      "name": "Lyn O'Grady"
+    },
+    {
+      "id": "west_coast_council/shane_pitt",
+      "name": "Shane Pitt"
+    },
+    {
+      "id": "west_coast_council/terry_shea",
+      "name": "Terry Shea"
+    },
+    {
+      "id": "west_coast_council/scott_stringer",
+      "name": "Scott Stringer"
+    },
+    {
+      "id": "west_coast_council/leigh_stlyes",
+      "name": "Leigh Stlyes"
+    },
+    {
+      "id": "west_coast_council/phil_vickers",
+      "name": "Phil Vickers"
+    },
+    {
+      "id": "west_tamar_council/joy_allen",
+      "name": "Joy Allen"
+    },
+    {
+      "id": "west_tamar_council/carol_bracken",
+      "name": "Carol Bracken"
+    },
+    {
+      "id": "west_tamar_council/linden_ferguson",
+      "name": "Linden Ferguson"
+    },
+    {
+      "id": "west_tamar_council/christina_holmdahl",
+      "name": "Christina Holmdahl"
+    },
+    {
+      "id": "west_tamar_council/richard_ireland",
+      "name": "Richard Ireland"
+    },
+    {
+      "id": "west_tamar_council/peter_kearney",
+      "name": "Peter Kearney"
+    },
+    {
+      "id": "west_tamar_council/geoff_lyons",
+      "name": "Geoff Lyons"
+    },
+    {
+      "id": "west_tamar_council/rich_shegog",
+      "name": "Rich Shegog"
+    },
+    {
+      "id": "west_tamar_council/tim_woinarski",
+      "name": "Tim Woinarski"
+    }
   ],
   "organizations": [
-
+    {
+      "id": "legislature/break_o'day_council",
+      "name": "Break O'Day Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/brighton_council",
+      "name": "Brighton Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/burnie_city_council",
+      "name": "Burnie City Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/central_coast_council",
+      "name": "Central Coast Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/central_highlands_council",
+      "name": "Central Highlands Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/circular_head_council",
+      "name": "Circular Head Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/clarence_city_council",
+      "name": "Clarence City Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/derwent_valley_council",
+      "name": "Derwent Valley Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/devonport_city_council",
+      "name": "Devonport City Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/dorset_council",
+      "name": "Dorset Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/flinders_council",
+      "name": "Flinders Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/george_town_council",
+      "name": "George Town Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/glamorgan-spring_bay_council",
+      "name": "Glamorgan-Spring Bay Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/glenorchy_city_council",
+      "name": "Glenorchy City Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/hobart_city_council",
+      "name": "Hobart City Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/huon_valley_council",
+      "name": "Huon Valley Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/kentish_council",
+      "name": "Kentish Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/king_island_council",
+      "name": "King Island Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/kingborough_council",
+      "name": "Kingborough Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/latrobe_council",
+      "name": "Latrobe Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/launceston_city_council",
+      "name": "Launceston City Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/meander_valley_council",
+      "name": "Meander Valley Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/northern_midlands_council",
+      "name": "Northern Midlands Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/sorell_council",
+      "name": "Sorell Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/southern_midlands_council",
+      "name": "Southern Midlands Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/tasman_council",
+      "name": "Tasman Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/waratah-wynyard_council",
+      "name": "Waratah-Wynyard Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/west_coast_council",
+      "name": "West Coast Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/west_tamar_council",
+      "name": "West Tamar Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "party/unknown",
+      "name": "unknown",
+      "classification": "party"
+    },
+    {
+      "id": "party/independent",
+      "name": "Independent",
+      "classification": "party"
+    },
+    {
+      "id": "party/_greens",
+      "name": " Greens",
+      "classification": "party"
+    }
   ],
   "memberships": [
-
+    {
+      "person_id": "break_o'day_council/janet_drummond",
+      "organization_id": "legislature/break_o'day_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "break_o'day_council/barry_le_fevre",
+      "organization_id": "legislature/break_o'day_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "break_o'day_council/john_mcgiveron",
+      "organization_id": "legislature/break_o'day_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "break_o'day_council/glenn_mcguiness",
+      "organization_id": "legislature/break_o'day_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "break_o'day_council/margaret_osborne",
+      "organization_id": "legislature/break_o'day_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "break_o'day_council/hannah_rubenach",
+      "organization_id": "legislature/break_o'day_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "break_o'day_council/john_tucker",
+      "organization_id": "legislature/break_o'day_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "break_o'day_council/mick_tucker",
+      "organization_id": "legislature/break_o'day_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "break_o'day_council/kylie_wright",
+      "organization_id": "legislature/break_o'day_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "brighton_council/barbara_curran",
+      "organization_id": "legislature/brighton_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "brighton_council/tony_foster",
+      "organization_id": "legislature/brighton_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "brighton_council/wayne_garlick",
+      "organization_id": "legislature/brighton_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "brighton_council/peter_geard",
+      "organization_id": "legislature/brighton_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "brighton_council/leigh_gray",
+      "organization_id": "legislature/brighton_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "brighton_council/moya_jeffries",
+      "organization_id": "legislature/brighton_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "brighton_council/phil_owen",
+      "organization_id": "legislature/brighton_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "brighton_council/geoff_taylor",
+      "organization_id": "legislature/brighton_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "brighton_council/sonya_williams",
+      "organization_id": "legislature/brighton_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "burnie_city_council/robert_bentley",
+      "organization_id": "legislature/burnie_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "burnie_city_council/ron_blake",
+      "organization_id": "legislature/burnie_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "burnie_city_council/alvwyn_boyd",
+      "organization_id": "legislature/burnie_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "burnie_city_council/teeny_brumby",
+      "organization_id": "legislature/burnie_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "burnie_city_council/ken_dorsey",
+      "organization_id": "legislature/burnie_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "burnie_city_council/anita_dow",
+      "organization_id": "legislature/burnie_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "burnie_city_council/sandra_french",
+      "organization_id": "legislature/burnie_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "burnie_city_council/steven_kons",
+      "organization_id": "legislature/burnie_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "burnie_city_council/chris_lynch",
+      "organization_id": "legislature/burnie_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "central_coast_council/john_bloomfield",
+      "organization_id": "legislature/central_coast_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "central_coast_council/jan_bonde",
+      "organization_id": "legislature/central_coast_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "central_coast_council/shane_broad",
+      "organization_id": "legislature/central_coast_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "central_coast_council/garry_carpenter",
+      "organization_id": "legislature/central_coast_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "central_coast_council/kath_downie",
+      "organization_id": "legislature/central_coast_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "central_coast_council/gerry_howard",
+      "organization_id": "legislature/central_coast_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "central_coast_council/rowen_tongs",
+      "organization_id": "legislature/central_coast_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "central_coast_council/tony_van_rooyen",
+      "organization_id": "legislature/central_coast_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "central_coast_council/phillip_viney",
+      "organization_id": "legislature/central_coast_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "central_highlands_council/jim_allwright",
+      "organization_id": "legislature/central_highlands_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "central_highlands_council/tony_bailey",
+      "organization_id": "legislature/central_highlands_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "central_highlands_council/richard_bowden",
+      "organization_id": "legislature/central_highlands_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "central_highlands_council/robert_cassidy",
+      "organization_id": "legislature/central_highlands_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "central_highlands_council/andrew_downie",
+      "organization_id": "legislature/central_highlands_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "central_highlands_council/evan_evans",
+      "organization_id": "legislature/central_highlands_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "central_highlands_council/deirdre_flint",
+      "organization_id": "legislature/central_highlands_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "central_highlands_council/erika_mcrae",
+      "organization_id": "legislature/central_highlands_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "central_highlands_council/loueen_(lou)_triffitt",
+      "organization_id": "legislature/central_highlands_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "circular_head_council/norman_berechree",
+      "organization_id": "legislature/circular_head_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "circular_head_council/jan_bishop",
+      "organization_id": "legislature/circular_head_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "circular_head_council/rod_hardy",
+      "organization_id": "legislature/circular_head_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "circular_head_council/betty_kay",
+      "organization_id": "legislature/circular_head_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "circular_head_council/john_oldaker",
+      "organization_id": "legislature/circular_head_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "circular_head_council/ashley_popowski",
+      "organization_id": "legislature/circular_head_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "circular_head_council/nakore_popowski",
+      "organization_id": "legislature/circular_head_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "circular_head_council/daryl_quilliam",
+      "organization_id": "legislature/circular_head_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "circular_head_council/trevor_spinks",
+      "organization_id": "legislature/circular_head_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "clarence_city_council/jock_campbell",
+      "organization_id": "legislature/clarence_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/independent"
+    },
+    {
+      "person_id": "clarence_city_council/doug_chipman",
+      "organization_id": "legislature/clarence_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/independent"
+    },
+    {
+      "person_id": "clarence_city_council/heather_chong",
+      "organization_id": "legislature/clarence_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/independent"
+    },
+    {
+      "person_id": "clarence_city_council/peter_cusick",
+      "organization_id": "legislature/clarence_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/independent"
+    },
+    {
+      "person_id": "clarence_city_council/doug_doust",
+      "organization_id": "legislature/clarence_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/independent"
+    },
+    {
+      "person_id": "clarence_city_council/daniel_hulme",
+      "organization_id": "legislature/clarence_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/independent"
+    },
+    {
+      "person_id": "clarence_city_council/richard_james",
+      "organization_id": "legislature/clarence_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/independent"
+    },
+    {
+      "person_id": "clarence_city_council/kay_mcfarlane",
+      "organization_id": "legislature/clarence_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/_greens"
+    },
+    {
+      "person_id": "clarence_city_council/jonn_peers",
+      "organization_id": "legislature/clarence_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/independent"
+    },
+    {
+      "person_id": "clarence_city_council/debra_thurley",
+      "organization_id": "legislature/clarence_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/independent"
+    },
+    {
+      "person_id": "clarence_city_council/sharyn_von_bertouch",
+      "organization_id": "legislature/clarence_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/independent"
+    },
+    {
+      "person_id": "clarence_city_council/james_walker",
+      "organization_id": "legislature/clarence_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/independent"
+    },
+    {
+      "person_id": "derwent_valley_council/paul_belcher",
+      "organization_id": "legislature/derwent_valley_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "derwent_valley_council/damian_bester",
+      "organization_id": "legislature/derwent_valley_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "derwent_valley_council/martyn_evans",
+      "organization_id": "legislature/derwent_valley_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "derwent_valley_council/james_graham",
+      "organization_id": "legislature/derwent_valley_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "derwent_valley_council/barry_lathey",
+      "organization_id": "legislature/derwent_valley_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "derwent_valley_council/frank_pearce",
+      "organization_id": "legislature/derwent_valley_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "derwent_valley_council/ben_shaw",
+      "organization_id": "legislature/derwent_valley_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "derwent_valley_council/julie_triffett",
+      "organization_id": "legislature/derwent_valley_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "devonport_city_council/charlie_emmerton",
+      "organization_id": "legislature/devonport_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "devonport_city_council/grant_goodwin",
+      "organization_id": "legislature/devonport_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "devonport_city_council/alison_jarman",
+      "organization_id": "legislature/devonport_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "devonport_city_council/justine_keay",
+      "organization_id": "legislature/devonport_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "devonport_city_council/lynn_laycock",
+      "organization_id": "legislature/devonport_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "devonport_city_council/jeff_matthews",
+      "organization_id": "legislature/devonport_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "devonport_city_council/steve_martin",
+      "organization_id": "legislature/devonport_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "devonport_city_council/leon_perry",
+      "organization_id": "legislature/devonport_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "devonport_city_council/annette_rockliff",
+      "organization_id": "legislature/devonport_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "dorset_council/lawrence_archer",
+      "organization_id": "legislature/dorset_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "dorset_council/steven_arnold",
+      "organization_id": "legislature/dorset_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "dorset_council/maxwell_hall",
+      "organization_id": "legislature/dorset_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "dorset_council/greg_howard",
+      "organization_id": "legislature/dorset_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "dorset_council/dale_jessup",
+      "organization_id": "legislature/dorset_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "dorset_council/sheryl_martin",
+      "organization_id": "legislature/dorset_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "dorset_council/shaun_moore",
+      "organization_id": "legislature/dorset_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "dorset_council/leon_quilliam",
+      "organization_id": "legislature/dorset_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "dorset_council/leonie_stein",
+      "organization_id": "legislature/dorset_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "flinders_council/marc_cobham",
+      "organization_id": "legislature/flinders_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "flinders_council/carol_cox",
+      "organization_id": "legislature/flinders_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "flinders_council/chris_rhodes",
+      "organization_id": "legislature/flinders_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "flinders_council/peter_rhodes",
+      "organization_id": "legislature/flinders_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "flinders_council/ken_stockton",
+      "organization_id": "legislature/flinders_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "flinders_council/david_williams",
+      "organization_id": "legislature/flinders_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "flinders_council/gerald_willis",
+      "organization_id": "legislature/flinders_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "george_town_council/bridget_archer",
+      "organization_id": "legislature/george_town_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "george_town_council/heather_barwick",
+      "organization_id": "legislature/george_town_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "george_town_council/doug_burt",
+      "organization_id": "legislature/george_town_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "george_town_council/greg_dawson",
+      "organization_id": "legislature/george_town_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "george_town_council/john_glisson",
+      "organization_id": "legislature/george_town_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "george_town_council/tim_harris",
+      "organization_id": "legislature/george_town_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "george_town_council/richard_nicholls",
+      "organization_id": "legislature/george_town_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "george_town_council/tim_parish",
+      "organization_id": "legislature/george_town_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "george_town_council/peter_parkes",
+      "organization_id": "legislature/george_town_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "glamorgan-spring_bay_council/cheryl_arnol",
+      "organization_id": "legislature/glamorgan-spring_bay_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "glamorgan-spring_bay_council/bertrand_cadart",
+      "organization_id": "legislature/glamorgan-spring_bay_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "glamorgan-spring_bay_council/jenifer_crawford",
+      "organization_id": "legislature/glamorgan-spring_bay_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "glamorgan-spring_bay_council/michael_kent",
+      "organization_id": "legislature/glamorgan-spring_bay_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "glamorgan-spring_bay_council/greg_raspin",
+      "organization_id": "legislature/glamorgan-spring_bay_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "glamorgan-spring_bay_council/britt_steiner",
+      "organization_id": "legislature/glamorgan-spring_bay_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "glamorgan-spring_bay_council/debbie_wisby",
+      "organization_id": "legislature/glamorgan-spring_bay_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "glamorgan-spring_bay_council/jenny_woods",
+      "organization_id": "legislature/glamorgan-spring_bay_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "glenorchy_city_council/jennifer_branch-allen",
+      "organization_id": "legislature/glenorchy_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "glenorchy_city_council/jan_dunsby",
+      "organization_id": "legislature/glenorchy_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "glenorchy_city_council/kristie_johnston",
+      "organization_id": "legislature/glenorchy_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "glenorchy_city_council/steven_king",
+      "organization_id": "legislature/glenorchy_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "glenorchy_city_council/christine_lucas",
+      "organization_id": "legislature/glenorchy_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "glenorchy_city_council/haydyn_nielsen",
+      "organization_id": "legislature/glenorchy_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "glenorchy_city_council/david_pearce",
+      "organization_id": "legislature/glenorchy_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "glenorchy_city_council/harry_quick",
+      "organization_id": "legislature/glenorchy_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "glenorchy_city_council/stuart_slade",
+      "organization_id": "legislature/glenorchy_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "glenorchy_city_council/matt_stevenson",
+      "organization_id": "legislature/glenorchy_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "hobart_city_council/jeff_briscoe",
+      "organization_id": "legislature/hobart_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "hobart_city_council/helen_burnet",
+      "organization_id": "legislature/hobart_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "hobart_city_council/ron_christie",
+      "organization_id": "legislature/hobart_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "hobart_city_council/philip_cocker",
+      "organization_id": "legislature/hobart_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "hobart_city_council/suzy_cooper",
+      "organization_id": "legislature/hobart_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "hobart_city_council/tania_denison",
+      "organization_id": "legislature/hobart_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "hobart_city_council/sue_hickey",
+      "organization_id": "legislature/hobart_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "hobart_city_council/anna_reynolds",
+      "organization_id": "legislature/hobart_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "hobart_city_council/eva_ruzicka",
+      "organization_id": "legislature/hobart_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "hobart_city_council/peter_sexton",
+      "organization_id": "legislature/hobart_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "hobart_city_council/damon_thomas",
+      "organization_id": "legislature/hobart_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "hobart_city_council/marti_zucco",
+      "organization_id": "legislature/hobart_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "huon_valley_council/peter_coad",
+      "organization_id": "legislature/huon_valley_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "huon_valley_council/lydia_eastley",
+      "organization_id": "legislature/huon_valley_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "huon_valley_council/bruce_heron",
+      "organization_id": "legislature/huon_valley_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "huon_valley_council/ian_mackintosh",
+      "organization_id": "legislature/huon_valley_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "huon_valley_council/ian_paul",
+      "organization_id": "legislature/huon_valley_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "huon_valley_council/pavel_ruzicka",
+      "organization_id": "legislature/huon_valley_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "huon_valley_council/liz_smith",
+      "organization_id": "legislature/huon_valley_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "huon_valley_council/ken_studley",
+      "organization_id": "legislature/huon_valley_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "huon_valley_council/mike_wilson",
+      "organization_id": "legislature/huon_valley_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "kentish_council/rodney_blenkhorn",
+      "organization_id": "legislature/kentish_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "kentish_council/linda_cassidy",
+      "organization_id": "legislature/kentish_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "kentish_council/kate_haberle",
+      "organization_id": "legislature/kentish_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "kentish_council/terry_hughes",
+      "organization_id": "legislature/kentish_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "kentish_council/penny_lane",
+      "organization_id": "legislature/kentish_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "kentish_council/phillip_richards",
+      "organization_id": "legislature/kentish_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "kentish_council/don_thwaites",
+      "organization_id": "legislature/kentish_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "kentish_council/annie_willcock",
+      "organization_id": "legislature/kentish_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "kentish_council/tim_wilson",
+      "organization_id": "legislature/kentish_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "king_island_council/jim_benn",
+      "organization_id": "legislature/king_island_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "king_island_council/david_bowling",
+      "organization_id": "legislature/king_island_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "king_island_council/douglas_collins",
+      "organization_id": "legislature/king_island_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "king_island_council/royce_conley",
+      "organization_id": "legislature/king_island_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "king_island_council/jim_cooper",
+      "organization_id": "legislature/king_island_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "king_island_council/sally_haneveer",
+      "organization_id": "legislature/king_island_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "king_island_council/duncan_mcfie",
+      "organization_id": "legislature/king_island_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "king_island_council/david_munday",
+      "organization_id": "legislature/king_island_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "king_island_council/kirsty_russell",
+      "organization_id": "legislature/king_island_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "kingborough_council/richard_atkinson",
+      "organization_id": "legislature/kingborough_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "kingborough_council/sue_bastone",
+      "organization_id": "legislature/kingborough_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "kingborough_council/graham_bury",
+      "organization_id": "legislature/kingborough_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "kingborough_council/flora_fox",
+      "organization_id": "legislature/kingborough_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "kingborough_council/david_grace",
+      "organization_id": "legislature/kingborough_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "kingborough_council/michael_percey",
+      "organization_id": "legislature/kingborough_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "kingborough_council/nic_street",
+      "organization_id": "legislature/kingborough_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "kingborough_council/steve_wass",
+      "organization_id": "legislature/kingborough_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "kingborough_council/dean_winter",
+      "organization_id": "legislature/kingborough_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "kingborough_council/paula_wriedt",
+      "organization_id": "legislature/kingborough_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "latrobe_council/graeme_brown",
+      "organization_id": "legislature/latrobe_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "latrobe_council/dayna_dennison",
+      "organization_id": "legislature/latrobe_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "latrobe_council/peter_freshney",
+      "organization_id": "legislature/latrobe_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "latrobe_council/mike_mclaren",
+      "organization_id": "legislature/latrobe_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "latrobe_council/john_perkins",
+      "organization_id": "legislature/latrobe_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "latrobe_council/rick_rockliff",
+      "organization_id": "legislature/latrobe_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "latrobe_council/garry_sims",
+      "organization_id": "legislature/latrobe_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "latrobe_council/gerrad_wicks",
+      "organization_id": "legislature/latrobe_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "latrobe_council/lesley_young",
+      "organization_id": "legislature/latrobe_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "launceston_city_council/darren_alexander",
+      "organization_id": "legislature/launceston_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "launceston_city_council/jim_cox",
+      "organization_id": "legislature/launceston_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "launceston_city_council/janie_finlay",
+      "organization_id": "legislature/launceston_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "launceston_city_council/danny_gibson",
+      "organization_id": "legislature/launceston_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "launceston_city_council/robin_mckendrick",
+      "organization_id": "legislature/launceston_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "launceston_city_council/hugh_mckenzie",
+      "organization_id": "legislature/launceston_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "launceston_city_council/ted_sands",
+      "organization_id": "legislature/launceston_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "launceston_city_council/rob_soward",
+      "organization_id": "legislature/launceston_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "launceston_city_council/karina_stojansek",
+      "organization_id": "legislature/launceston_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "launceston_city_council/albert_van_zetten",
+      "organization_id": "legislature/launceston_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "launceston_city_council/emma_williams",
+      "organization_id": "legislature/launceston_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "launceston_city_council/simon_wood",
+      "organization_id": "legislature/launceston_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "meander_valley_council/andrew_connor",
+      "organization_id": "legislature/meander_valley_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "meander_valley_council/michael_kelly",
+      "organization_id": "legislature/meander_valley_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "meander_valley_council/tanya_king",
+      "organization_id": "legislature/meander_valley_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "meander_valley_council/ian_mackenzie",
+      "organization_id": "legislature/meander_valley_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "meander_valley_council/craig_perkins",
+      "organization_id": "legislature/meander_valley_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "meander_valley_council/bob_richardson",
+      "organization_id": "legislature/meander_valley_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "meander_valley_council/rodney_synfield",
+      "organization_id": "legislature/meander_valley_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "meander_valley_council/deborah_white",
+      "organization_id": "legislature/meander_valley_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "meander_valley_council/rodney_youd",
+      "organization_id": "legislature/meander_valley_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "northern_midlands_council/dick_adams",
+      "organization_id": "legislature/northern_midlands_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "northern_midlands_council/andrew_calvert",
+      "organization_id": "legislature/northern_midlands_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "northern_midlands_council/david_downie",
+      "organization_id": "legislature/northern_midlands_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "northern_midlands_council/ian_goninon",
+      "organization_id": "legislature/northern_midlands_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "northern_midlands_council/leisa_gordon",
+      "organization_id": "legislature/northern_midlands_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "northern_midlands_council/richard_goss",
+      "organization_id": "legislature/northern_midlands_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "northern_midlands_council/mary_knowles",
+      "organization_id": "legislature/northern_midlands_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "northern_midlands_council/janet_lambert",
+      "organization_id": "legislature/northern_midlands_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "northern_midlands_council/michael_polley",
+      "organization_id": "legislature/northern_midlands_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "sorell_council/deborah_de_williams",
+      "organization_id": "legislature/sorell_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "sorell_council/kerry_degrassi",
+      "organization_id": "legislature/sorell_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "sorell_council/graeme_evans",
+      "organization_id": "legislature/sorell_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "sorell_council/vlad_gala",
+      "organization_id": "legislature/sorell_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "sorell_council/brett_mcdonald",
+      "organization_id": "legislature/sorell_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "sorell_council/natham_reynolds",
+      "organization_id": "legislature/sorell_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "sorell_council/carmel_torenius",
+      "organization_id": "legislature/sorell_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "sorell_council/kerry_vincent",
+      "organization_id": "legislature/sorell_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "sorell_council/lindsay_white",
+      "organization_id": "legislature/sorell_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "southern_midlands_council/tony_bantick",
+      "organization_id": "legislature/southern_midlands_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "southern_midlands_council/edwin_batt",
+      "organization_id": "legislature/southern_midlands_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "southern_midlands_council/tony_bisdee",
+      "organization_id": "legislature/southern_midlands_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "southern_midlands_council/bob_campbell",
+      "organization_id": "legislature/southern_midlands_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "southern_midlands_council/donald_fish",
+      "organization_id": "legislature/southern_midlands_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "southern_midlands_council/alex_green",
+      "organization_id": "legislature/southern_midlands_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "southern_midlands_council/mark_jones",
+      "organization_id": "legislature/southern_midlands_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "tasman_council/pam_fenerty",
+      "organization_id": "legislature/tasman_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "tasman_council/roseanne_heyward",
+      "organization_id": "legislature/tasman_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "tasman_council/alan_hull",
+      "organization_id": "legislature/tasman_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "tasman_council/roger_larner",
+      "organization_id": "legislature/tasman_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "tasman_council/david_macdonald",
+      "organization_id": "legislature/tasman_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "tasman_council/kelly_spaulding",
+      "organization_id": "legislature/tasman_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "tasman_council/maria_stacey",
+      "organization_id": "legislature/tasman_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "waratah-wynyard_council/maureen_bradley",
+      "organization_id": "legislature/waratah-wynyard_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "waratah-wynyard_council/gary_bramich",
+      "organization_id": "legislature/waratah-wynyard_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "waratah-wynyard_council/mary_duniam",
+      "organization_id": "legislature/waratah-wynyard_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "waratah-wynyard_council/darren_fairbrother",
+      "organization_id": "legislature/waratah-wynyard_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "waratah-wynyard_council/alwyn_friedersdorff",
+      "organization_id": "legislature/waratah-wynyard_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "waratah-wynyard_council/kevin_hyland",
+      "organization_id": "legislature/waratah-wynyard_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "waratah-wynyard_council/robert_walsh",
+      "organization_id": "legislature/waratah-wynyard_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "waratah-wynyard_council/stephen_wright",
+      "organization_id": "legislature/waratah-wynyard_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "west_coast_council/robyn_gerrity",
+      "organization_id": "legislature/west_coast_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "west_coast_council/al_medwin",
+      "organization_id": "legislature/west_coast_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "west_coast_council/lindsay_newman",
+      "organization_id": "legislature/west_coast_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "west_coast_council/lyn_o'grady",
+      "organization_id": "legislature/west_coast_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "west_coast_council/shane_pitt",
+      "organization_id": "legislature/west_coast_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "west_coast_council/terry_shea",
+      "organization_id": "legislature/west_coast_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "west_coast_council/scott_stringer",
+      "organization_id": "legislature/west_coast_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "west_coast_council/leigh_stlyes",
+      "organization_id": "legislature/west_coast_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "west_coast_council/phil_vickers",
+      "organization_id": "legislature/west_coast_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "west_tamar_council/joy_allen",
+      "organization_id": "legislature/west_tamar_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "west_tamar_council/carol_bracken",
+      "organization_id": "legislature/west_tamar_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "west_tamar_council/linden_ferguson",
+      "organization_id": "legislature/west_tamar_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "west_tamar_council/christina_holmdahl",
+      "organization_id": "legislature/west_tamar_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "west_tamar_council/richard_ireland",
+      "organization_id": "legislature/west_tamar_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "west_tamar_council/peter_kearney",
+      "organization_id": "legislature/west_tamar_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "west_tamar_council/geoff_lyons",
+      "organization_id": "legislature/west_tamar_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "west_tamar_council/rich_shegog",
+      "organization_id": "legislature/west_tamar_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "west_tamar_council/tim_woinarski",
+      "organization_id": "legislature/west_tamar_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "break_o'day_council/john_mcgiveron",
+      "organization_id": "legislature/break_o'day_council",
+      "role": "Deputy Mayor"
+    },
+    {
+      "person_id": "break_o'day_council/mick_tucker",
+      "organization_id": "legislature/break_o'day_council",
+      "role": "Mayor"
+    },
+    {
+      "person_id": "brighton_council/barbara_curran",
+      "organization_id": "legislature/brighton_council",
+      "role": "Deputy Mayor"
+    },
+    {
+      "person_id": "brighton_council/tony_foster",
+      "organization_id": "legislature/brighton_council",
+      "role": "Mayor"
+    },
+    {
+      "person_id": "burnie_city_council/alvwyn_boyd",
+      "organization_id": "legislature/burnie_city_council",
+      "role": "Deputy Mayor"
+    },
+    {
+      "person_id": "burnie_city_council/anita_dow",
+      "organization_id": "legislature/burnie_city_council",
+      "role": "Mayor"
+    },
+    {
+      "person_id": "central_coast_council/jan_bonde",
+      "organization_id": "legislature/central_coast_council",
+      "role": "Mayor"
+    },
+    {
+      "person_id": "central_coast_council/kath_downie",
+      "organization_id": "legislature/central_coast_council",
+      "role": "Deputy Mayor"
+    },
+    {
+      "person_id": "central_highlands_council/andrew_downie",
+      "organization_id": "legislature/central_highlands_council",
+      "role": "Deputy Mayor"
+    },
+    {
+      "person_id": "central_highlands_council/deirdre_flint",
+      "organization_id": "legislature/central_highlands_council",
+      "role": "Mayor"
+    },
+    {
+      "person_id": "circular_head_council/jan_bishop",
+      "organization_id": "legislature/circular_head_council",
+      "role": "Deputy Mayor"
+    },
+    {
+      "person_id": "clarence_city_council/jock_campbell",
+      "organization_id": "legislature/clarence_city_council",
+      "role": "Deputy Mayor"
+    },
+    {
+      "person_id": "clarence_city_council/doug_chipman",
+      "organization_id": "legislature/clarence_city_council",
+      "role": "Mayor"
+    },
+    {
+      "person_id": "derwent_valley_council/martyn_evans",
+      "organization_id": "legislature/derwent_valley_council",
+      "role": "Mayor"
+    },
+    {
+      "person_id": "derwent_valley_council/ben_shaw",
+      "organization_id": "legislature/derwent_valley_council",
+      "role": "Deputy Mayor"
+    },
+    {
+      "person_id": "devonport_city_council/steve_martin",
+      "organization_id": "legislature/devonport_city_council",
+      "role": "Mayor"
+    },
+    {
+      "person_id": "devonport_city_council/annette_rockliff",
+      "organization_id": "legislature/devonport_city_council",
+      "role": "Deputy Mayor"
+    },
+    {
+      "person_id": "dorset_council/greg_howard",
+      "organization_id": "legislature/dorset_council",
+      "role": "Mayor"
+    },
+    {
+      "person_id": "flinders_council/marc_cobham",
+      "organization_id": "legislature/flinders_council",
+      "role": "Deputy Mayor"
+    },
+    {
+      "person_id": "flinders_council/carol_cox",
+      "organization_id": "legislature/flinders_council",
+      "role": "Mayor"
+    },
+    {
+      "person_id": "george_town_council/bridget_archer",
+      "organization_id": "legislature/george_town_council",
+      "role": "Mayor"
+    },
+    {
+      "person_id": "george_town_council/tim_harris",
+      "organization_id": "legislature/george_town_council",
+      "role": "Deputy Mayor"
+    },
+    {
+      "person_id": "glamorgan-spring_bay_council/michael_kent",
+      "organization_id": "legislature/glamorgan-spring_bay_council",
+      "role": "Mayor"
+    },
+    {
+      "person_id": "glenorchy_city_council/kristie_johnston",
+      "organization_id": "legislature/glenorchy_city_council",
+      "role": "Mayor"
+    },
+    {
+      "person_id": "glenorchy_city_council/harry_quick",
+      "organization_id": "legislature/glenorchy_city_council",
+      "role": "Deputy Mayor"
+    },
+    {
+      "person_id": "hobart_city_council/ron_christie",
+      "organization_id": "legislature/hobart_city_council",
+      "role": "Deputy Mayor"
+    },
+    {
+      "person_id": "hobart_city_council/sue_hickey",
+      "organization_id": "legislature/hobart_city_council",
+      "role": "Mayor"
+    },
+    {
+      "person_id": "huon_valley_council/peter_coad",
+      "organization_id": "legislature/huon_valley_council",
+      "role": "Mayor"
+    },
+    {
+      "person_id": "huon_valley_council/ian_paul",
+      "organization_id": "legislature/huon_valley_council",
+      "role": "Deputy Mayor"
+    },
+    {
+      "person_id": "kentish_council/don_thwaites",
+      "organization_id": "legislature/kentish_council",
+      "role": "Mayor"
+    },
+    {
+      "person_id": "kentish_council/tim_wilson",
+      "organization_id": "legislature/kentish_council",
+      "role": "Deputy Mayor"
+    },
+    {
+      "person_id": "king_island_council/jim_cooper",
+      "organization_id": "legislature/king_island_council",
+      "role": "Deputy Mayor"
+    },
+    {
+      "person_id": "king_island_council/duncan_mcfie",
+      "organization_id": "legislature/king_island_council",
+      "role": "Mayor"
+    },
+    {
+      "person_id": "kingborough_council/steve_wass",
+      "organization_id": "legislature/kingborough_council",
+      "role": "Mayor"
+    },
+    {
+      "person_id": "kingborough_council/paula_wriedt",
+      "organization_id": "legislature/kingborough_council",
+      "role": "Deputy Mayor"
+    },
+    {
+      "person_id": "latrobe_council/peter_freshney",
+      "organization_id": "legislature/latrobe_council",
+      "role": "Mayor"
+    },
+    {
+      "person_id": "latrobe_council/rick_rockliff",
+      "organization_id": "legislature/latrobe_council",
+      "role": "Deputy Mayor"
+    },
+    {
+      "person_id": "launceston_city_council/rob_soward",
+      "organization_id": "legislature/launceston_city_council",
+      "role": "Deputy Mayor"
+    },
+    {
+      "person_id": "launceston_city_council/albert_van_zetten",
+      "organization_id": "legislature/launceston_city_council",
+      "role": "Mayor"
+    },
+    {
+      "person_id": "meander_valley_council/michael_kelly",
+      "organization_id": "legislature/meander_valley_council",
+      "role": "Deputy Mayor"
+    },
+    {
+      "person_id": "meander_valley_council/craig_perkins",
+      "organization_id": "legislature/meander_valley_council",
+      "role": "Mayor"
+    },
+    {
+      "person_id": "northern_midlands_council/david_downie",
+      "organization_id": "legislature/northern_midlands_council",
+      "role": "Mayor"
+    },
+    {
+      "person_id": "northern_midlands_council/richard_goss",
+      "organization_id": "legislature/northern_midlands_council",
+      "role": "Deputy Mayor"
+    },
+    {
+      "person_id": "sorell_council/brett_mcdonald",
+      "organization_id": "legislature/sorell_council",
+      "role": "Deputy Mayor"
+    },
+    {
+      "person_id": "sorell_council/kerry_vincent",
+      "organization_id": "legislature/sorell_council",
+      "role": "Mayor"
+    },
+    {
+      "person_id": "southern_midlands_council/tony_bisdee",
+      "organization_id": "legislature/southern_midlands_council",
+      "role": "Mayor"
+    },
+    {
+      "person_id": "southern_midlands_council/mark_jones",
+      "organization_id": "legislature/southern_midlands_council",
+      "role": "Deputy Mayor"
+    },
+    {
+      "person_id": "tasman_council/roseanne_heyward",
+      "organization_id": "legislature/tasman_council",
+      "role": "Mayor"
+    },
+    {
+      "person_id": "tasman_council/kelly_spaulding",
+      "organization_id": "legislature/tasman_council",
+      "role": "Deputy Mayor"
+    },
+    {
+      "person_id": "waratah-wynyard_council/mary_duniam",
+      "organization_id": "legislature/waratah-wynyard_council",
+      "role": "Deputy Mayor"
+    },
+    {
+      "person_id": "west_coast_council/shane_pitt",
+      "organization_id": "legislature/west_coast_council",
+      "role": "Deputy Mayor"
+    },
+    {
+      "person_id": "west_coast_council/phil_vickers",
+      "organization_id": "legislature/west_coast_council",
+      "role": "Mayor"
+    },
+    {
+      "person_id": "west_tamar_council/joy_allen",
+      "organization_id": "legislature/west_tamar_council",
+      "role": "Deputy Mayor"
+    },
+    {
+      "person_id": "west_tamar_council/christina_holmdahl",
+      "organization_id": "legislature/west_tamar_council",
+      "role": "Mayor"
+    }
   ],
   "events": [
 
   ],
   "areas": [
 
-  ]
+  ],
+  "warnings": {
+    "skipped": [
+      "council_website",
+      "council_email",
+      "phone_mobile",
+      "ward",
+      "term_ends"
+    ]
+  }
 }


### PR DESCRIPTION
This adds base data (name, id) for all Tasmanian councillors and the emails, images and source for Launceston and Clarence City Council.