### PR TITLE
MEGA COMMIT: Refresh all QLD councillors

### DIFF
--- a/qld_local_councillor_popolo.json
+++ b/qld_local_councillor_popolo.json
@@ -1,20 +1,68 @@
 {
   "persons": [
     {
-      "id": "banana_shire_council/ron_carige",
-      "name": "Ron Carige"
+      "id": "aurukun_shire_council/dereck_walpo",
+      "name": "Dereck Walpo"
     },
     {
-      "id": "banana_shire_council/david_snell",
-      "name": "David Snell"
+      "id": "aurukun_shire_council/doris_poonkamelya",
+      "name": "Doris Poonkamelya"
     },
     {
-      "id": "banana_shire_council/maureen_clancy",
-      "name": "Maureen Clancy"
+      "id": "aurukun_shire_council/ada_woolla",
+      "name": "Ada Woolla"
+    },
+    {
+      "id": "aurukun_shire_council/edgar_kerindun",
+      "name": "Edgar Kerindun"
+    },
+    {
+      "id": "aurukun_shire_council/vera_komeeta",
+      "name": "Vera Komeeta"
+    },
+    {
+      "id": "balonne_shire_council/richard_marsh",
+      "name": "Richard Marsh"
+    },
+    {
+      "id": "balonne_shire_council/samantha_o'toole",
+      "name": "Samantha O'Toole"
+    },
+    {
+      "id": "balonne_shire_council/scott_scriven",
+      "name": "Scott Scriven"
+    },
+    {
+      "id": "balonne_shire_council/robyn_fuhrmeister",
+      "name": "Robyn Fuhrmeister"
+    },
+    {
+      "id": "balonne_shire_council/ian_todd",
+      "name": "Ian Todd"
+    },
+    {
+      "id": "balonne_shire_council/fiona_gaske",
+      "name": "Fiona Gaske"
+    },
+    {
+      "id": "balonne_shire_council/robert_paul",
+      "name": "Robert Paul"
     },
     {
       "id": "banana_shire_council/nev_ferrier",
       "name": "Nev Ferrier"
+    },
+    {
+      "id": "banana_shire_council/colin_semple",
+      "name": "Colin Semple"
+    },
+    {
+      "id": "banana_shire_council/brooke_leo",
+      "name": "Brooke Leo"
+    },
+    {
+      "id": "banana_shire_council/david_snell",
+      "name": "David Snell"
     },
     {
       "id": "banana_shire_council/pat_brennan",
@@ -33,8 +81,16 @@
       "name": "Robert Chandler"
     },
     {
-      "id": "barcaldine_regional_council/andrew_cowper",
-      "name": "Andrew Cowper"
+      "id": "barcaldine_regional_council/sean_dillon",
+      "name": "Sean Dillon"
+    },
+    {
+      "id": "barcaldine_regional_council/milynda_rogers",
+      "name": "Milynda Rogers"
+    },
+    {
+      "id": "barcaldine_regional_council/rebecca_plumb",
+      "name": "Rebecca Plumb"
     },
     {
       "id": "barcaldine_regional_council/garry_bettiens",
@@ -49,24 +105,16 @@
       "name": "Jenni Gray"
     },
     {
-      "id": "barcaldine_regional_council/phillip_mitchell",
-      "name": "Phillip Mitchell"
+      "id": "barcoo_shire_council/bruce_scott",
+      "name": "Bruce Scott"
     },
     {
-      "id": "barcaldine_regional_council/russ_glindemann",
-      "name": "Russ Glindemann"
+      "id": "barcoo_shire_council/dianne_pidgeon",
+      "name": "Dianne Pidgeon"
     },
     {
-      "id": "barcoo_shire_council/julie_groves",
-      "name": "Julie Groves"
-    },
-    {
-      "id": "barcoo_shire_council/craig_lasker",
-      "name": "Craig Lasker"
-    },
-    {
-      "id": "barcoo_shire_council/ian_groves",
-      "name": "Ian Groves"
+      "id": "barcoo_shire_council/jill_fitzgerald",
+      "name": "Jill Fitzgerald"
     },
     {
       "id": "barcoo_shire_council/michael_pratt",
@@ -81,28 +129,28 @@
       "name": "Barry Muir"
     },
     {
-      "id": "blackall-tambo_regional_council/jeremy_barron",
-      "name": "Jeremy Barron"
+      "id": "blackall-tambo_regional_council/graham_jarvis",
+      "name": "Graham Jarvis"
     },
     {
-      "id": "blackall-tambo_regional_council/megan_prow",
-      "name": "Megan Prow"
+      "id": "blackall-tambo_regional_council/lindsay_russell",
+      "name": "Lindsay Russell"
     },
     {
-      "id": "blackall-tambo_regional_council/neville_dolinski",
-      "name": "Neville Dolinski"
+      "id": "blackall-tambo_regional_council/hector_heumiller",
+      "name": "Hector Heumiller"
     },
     {
-      "id": "blackall-tambo_regional_council/richelle_johnson",
-      "name": "Richelle Johnson"
+      "id": "blackall-tambo_regional_council/pam_pullos",
+      "name": "Pam Pullos"
     },
     {
-      "id": "blackall-tambo_regional_council/terry_brennan",
-      "name": "Terry Brennan"
+      "id": "blackall-tambo_regional_council/ben_holdcroft",
+      "name": "Ben Holdcroft"
     },
     {
-      "id": "blackall-tambo_regional_council/tom_johnstone",
-      "name": "Tom Johnstone"
+      "id": "blackall-tambo_regional_council/boyd_johnstone",
+      "name": "Boyd Johnstone"
     },
     {
       "id": "boulia_shire_council/eric_charles_britton",
@@ -113,1332 +161,16 @@
       "name": "Allan Robinson"
     },
     {
+      "id": "boulia_shire_council/rebecka_britton",
+      "name": "Rebecka Britton"
+    },
+    {
       "id": "boulia_shire_council/brook_mcglinchey",
       "name": "Brook McGlinchey"
     },
     {
-      "id": "boulia_shire_council/geoff_norton",
-      "name": "Geoff Norton"
-    },
-    {
-      "id": "boulia_shire_council/kelsey_neilson",
-      "name": "Kelsey Neilson"
-    },
-    {
       "id": "boulia_shire_council/sam_beauchamp",
       "name": "Sam Beauchamp"
-    },
-    {
-      "id": "central_highlands_regional_council/peter_maguire",
-      "name": "Peter Maguire"
-    },
-    {
-      "id": "central_highlands_regional_council/charlie_brimblecombe",
-      "name": "Charlie Brimblecombe"
-    },
-    {
-      "id": "central_highlands_regional_council/gai_sypher",
-      "name": "Gai Sypher"
-    },
-    {
-      "id": "central_highlands_regional_council/gail_godwin-smith",
-      "name": "Gail Godwin-Smith"
-    },
-    {
-      "id": "central_highlands_regional_council/gail_nixon",
-      "name": "Gail Nixon"
-    },
-    {
-      "id": "central_highlands_regional_council/kev_cracknell",
-      "name": "Kev Cracknell"
-    },
-    {
-      "id": "central_highlands_regional_council/kevin_pickersgill",
-      "name": "Kevin Pickersgill"
-    },
-    {
-      "id": "central_highlands_regional_council/paul_bell",
-      "name": "Paul Bell"
-    },
-    {
-      "id": "central_highlands_regional_council/peter_maundrell",
-      "name": "Peter Maundrell"
-    },
-    {
-      "id": "diamantina_shire_council/geoff_morton",
-      "name": "Geoff Morton"
-    },
-    {
-      "id": "diamantina_shire_council/don_rayment",
-      "name": "Don Rayment"
-    },
-    {
-      "id": "diamantina_shire_council/garth_tully",
-      "name": "Garth Tully"
-    },
-    {
-      "id": "diamantina_shire_council/jody_barr",
-      "name": "Jody Barr"
-    },
-    {
-      "id": "diamantina_shire_council/stephen_cramer",
-      "name": "Stephen Cramer"
-    },
-    {
-      "id": "gladstone_regional_council/gail_sellers",
-      "name": "Gail Sellers"
-    },
-    {
-      "id": "gladstone_regional_council/colin_chapman",
-      "name": "Colin Chapman"
-    },
-    {
-      "id": "gladstone_regional_council/graham_mcdonald",
-      "name": "Graham McDonald"
-    },
-    {
-      "id": "gladstone_regional_council/karen_porter",
-      "name": "Karen Porter"
-    },
-    {
-      "id": "gladstone_regional_council/matt_burnett",
-      "name": "Matt Burnett"
-    },
-    {
-      "id": "gladstone_regional_council/maxine_brushe",
-      "name": "Maxine Brushe"
-    },
-    {
-      "id": "gladstone_regional_council/ren_lanzon",
-      "name": "Ren Lanzon"
-    },
-    {
-      "id": "gladstone_regional_council/rick_hansen",
-      "name": "Rick Hansen"
-    },
-    {
-      "id": "gladstone_regional_council/pj_sobhanian",
-      "name": "PJ Sobhanian"
-    },
-    {
-      "id": "isaac_regional_council/anne_baker",
-      "name": "Anne Baker"
-    },
-    {
-      "id": "isaac_regional_council/barbara_stranks",
-      "name": "Barbara Stranks"
-    },
-    {
-      "id": "isaac_regional_council/dale_appleton",
-      "name": "Dale Appleton"
-    },
-    {
-      "id": "isaac_regional_council/delville_(nick)_wheeler",
-      "name": "Delville (Nick) Wheeler"
-    },
-    {
-      "id": "isaac_regional_council/geoffrey_bethel",
-      "name": "Geoffrey Bethel"
-    },
-    {
-      "id": "isaac_regional_council/gina_lacey",
-      "name": "Gina Lacey"
-    },
-    {
-      "id": "isaac_regional_council/jane_pickels",
-      "name": "Jane Pickels"
-    },
-    {
-      "id": "isaac_regional_council/kelly_vea_vea",
-      "name": "Kelly Vea Vea"
-    },
-    {
-      "id": "isaac_regional_council/peter_freeleagus",
-      "name": "Peter Freeleagus"
-    },
-    {
-      "id": "longreach_regional_council/joe_owens",
-      "name": "Joe Owens"
-    },
-    {
-      "id": "longreach_regional_council/anthony_emslie",
-      "name": "Anthony Emslie"
-    },
-    {
-      "id": "longreach_regional_council/david_morton",
-      "name": "David Morton"
-    },
-    {
-      "id": "longreach_regional_council/jocelyn_avery",
-      "name": "Jocelyn Avery"
-    },
-    {
-      "id": "longreach_regional_council/norma_rae_bowden",
-      "name": "Norma Rae Bowden"
-    },
-    {
-      "id": "longreach_regional_council/tony_nielsen",
-      "name": "Tony Nielsen"
-    },
-    {
-      "id": "longreach_regional_council/trevor_smith",
-      "name": "Trevor Smith"
-    },
-    {
-      "id": "mackay_regional_council/deirdre_comerford",
-      "name": "Deirdre Comerford"
-    },
-    {
-      "id": "mackay_regional_council/alison_jones",
-      "name": "Alison Jones"
-    },
-    {
-      "id": "mackay_regional_council/chris_bonanno",
-      "name": "Chris Bonanno"
-    },
-    {
-      "id": "mackay_regional_council/david_perkins",
-      "name": "David Perkins"
-    },
-    {
-      "id": "mackay_regional_council/frank_gilbert",
-      "name": "Frank Gilbert"
-    },
-    {
-      "id": "mackay_regional_council/greg_martin",
-      "name": "Greg Martin"
-    },
-    {
-      "id": "mackay_regional_council/kevin_casey",
-      "name": "Kevin Casey"
-    },
-    {
-      "id": "mackay_regional_council/laurence_bonaventura",
-      "name": "Laurence Bonaventura"
-    },
-    {
-      "id": "mackay_regional_council/paul_steindl",
-      "name": "Paul Steindl"
-    },
-    {
-      "id": "mackay_regional_council/ross_walker",
-      "name": "Ross Walker"
-    },
-    {
-      "id": "mackay_regional_council/theresa_morgan",
-      "name": "Theresa Morgan"
-    },
-    {
-      "id": "rockhampton_regional_council/margaret_strelow",
-      "name": "Margaret Strelow"
-    },
-    {
-      "id": "rockhampton_regional_council/cherie_rutherford",
-      "name": "Cherie Rutherford"
-    },
-    {
-      "id": "rockhampton_regional_council/ellen_smith",
-      "name": "Ellen Smith"
-    },
-    {
-      "id": "rockhampton_regional_council/greg_belz",
-      "name": "Greg Belz"
-    },
-    {
-      "id": "rockhampton_regional_council/neil_fisher",
-      "name": "Neil Fisher"
-    },
-    {
-      "id": "rockhampton_regional_council/rose_swadling",
-      "name": "Rose Swadling"
-    },
-    {
-      "id": "rockhampton_regional_council/stephen_schwarten",
-      "name": "Stephen Schwarten"
-    },
-    {
-      "id": "rockhampton_regional_council/tony_williams",
-      "name": "Tony Williams"
-    },
-    {
-      "id": "whitsunday_regional_council/jennifer_(jenny)_whitney",
-      "name": "Jennifer (Jenny) Whitney"
-    },
-    {
-      "id": "whitsunday_regional_council/john_atkinson",
-      "name": "John Atkinson"
-    },
-    {
-      "id": "whitsunday_regional_council/andrew_willcox",
-      "name": "Andrew Willcox"
-    },
-    {
-      "id": "whitsunday_regional_council/dave_clark",
-      "name": "Dave Clark"
-    },
-    {
-      "id": "whitsunday_regional_council/jan_clifford",
-      "name": "Jan Clifford"
-    },
-    {
-      "id": "whitsunday_regional_council/john_collins",
-      "name": "John Collins"
-    },
-    {
-      "id": "whitsunday_regional_council/peter_ramage",
-      "name": "Peter Ramage"
-    },
-    {
-      "id": "winton_shire_council/butch_lenton",
-      "name": "Butch Lenton"
-    },
-    {
-      "id": "winton_shire_council/emma_forster",
-      "name": "Emma Forster"
-    },
-    {
-      "id": "winton_shire_council/judy_sale",
-      "name": "Judy Sale"
-    },
-    {
-      "id": "winton_shire_council/lyn_fraser",
-      "name": "Lyn Fraser"
-    },
-    {
-      "id": "winton_shire_council/robyn_stephens",
-      "name": "Robyn Stephens"
-    },
-    {
-      "id": "winton_shire_council/shane_mann",
-      "name": "Shane Mann"
-    },
-    {
-      "id": "woorabinda_aboriginal_shire_council/terry_munns",
-      "name": "Terry Munns"
-    },
-    {
-      "id": "woorabinda_aboriginal_shire_council/archie_williams",
-      "name": "Archie Williams"
-    },
-    {
-      "id": "woorabinda_aboriginal_shire_council/dellas_walker",
-      "name": "Dellas Walker"
-    },
-    {
-      "id": "woorabinda_aboriginal_shire_council/pamela_adams",
-      "name": "Pamela Adams"
-    },
-    {
-      "id": "woorabinda_aboriginal_shire_council/william_gulf",
-      "name": "William Gulf"
-    },
-    {
-      "id": "aurukun_shire_council/dereck_walpo",
-      "name": "Dereck Walpo"
-    },
-    {
-      "id": "aurukun_shire_council/ada_woolla",
-      "name": "Ada Woolla"
-    },
-    {
-      "id": "aurukun_shire_council/angus_kerindun",
-      "name": "Angus Kerindun"
-    },
-    {
-      "id": "aurukun_shire_council/edgar_kerindun",
-      "name": "Edgar Kerindun"
-    },
-    {
-      "id": "aurukun_shire_council/vera_komeeta",
-      "name": "Vera Komeeta"
-    },
-    {
-      "id": "burdekin_shire_council/bill_lowis",
-      "name": "Bill Lowis"
-    },
-    {
-      "id": "burdekin_shire_council/lou_loizou",
-      "name": "Lou Loizou"
-    },
-    {
-      "id": "burdekin_shire_council/lyndy_mccathie",
-      "name": "Lyndy McCathie"
-    },
-    {
-      "id": "burdekin_shire_council/pierina_dalle_cort",
-      "name": "Pierina Dalle Cort"
-    },
-    {
-      "id": "burdekin_shire_council/ross_lewis",
-      "name": "Ross Lewis"
-    },
-    {
-      "id": "burdekin_shire_council/ted_bawden",
-      "name": "Ted Bawden"
-    },
-    {
-      "id": "burdekin_shire_council/uli_liessmann",
-      "name": "Uli Liessmann"
-    },
-    {
-      "id": "burke_shire_council/ernie_camp",
-      "name": "Ernie Camp"
-    },
-    {
-      "id": "burke_shire_council/larissa_lauder",
-      "name": "Larissa Lauder"
-    },
-    {
-      "id": "burke_shire_council/paul_poole",
-      "name": "Paul Poole"
-    },
-    {
-      "id": "burke_shire_council/tonya_murray",
-      "name": "Tonya Murray"
-    },
-    {
-      "id": "burke_shire_council/tracy_forshaw",
-      "name": "Tracy Forshaw"
-    },
-    {
-      "id": "burke_shire_council/zachary_duff",
-      "name": "Zachary Duff"
-    },
-    {
-      "id": "cairns_regional_council/bob_manning_oam",
-      "name": "Bob Manning OAM"
-    },
-    {
-      "id": "cairns_regional_council/gregory_fennell",
-      "name": "Gregory Fennell"
-    },
-    {
-      "id": "cairns_regional_council/jessie_richardson",
-      "name": "Jessie Richardson"
-    },
-    {
-      "id": "cairns_regional_council/john_schilling",
-      "name": "John Schilling"
-    },
-    {
-      "id": "cairns_regional_council/linda_cooper",
-      "name": "Linda Cooper"
-    },
-    {
-      "id": "cairns_regional_council/max_o'halloran",
-      "name": "Max O'Halloran"
-    },
-    {
-      "id": "cairns_regional_council/richie_bates",
-      "name": "Richie Bates"
-    },
-    {
-      "id": "cairns_regional_council/cathy_zeiger",
-      "name": "Cathy Zeiger"
-    },
-    {
-      "id": "cairns_regional_council/steve_brain",
-      "name": "Steve Brain"
-    },
-    {
-      "id": "cairns_regional_council/terry_james",
-      "name": "Terry James"
-    },
-    {
-      "id": "carpentaria_shire_council/fred_pascoe",
-      "name": "Fred Pascoe"
-    },
-    {
-      "id": "carpentaria_shire_council/alan_gurney",
-      "name": "Alan Gurney"
-    },
-    {
-      "id": "carpentaria_shire_council/ashley_gallagher",
-      "name": "Ashley Gallagher"
-    },
-    {
-      "id": "carpentaria_shire_council/john_beard",
-      "name": "John Beard"
-    },
-    {
-      "id": "carpentaria_shire_council/joyce_zahner",
-      "name": "Joyce Zahner"
-    },
-    {
-      "id": "carpentaria_shire_council/merle_johnson",
-      "name": "Merle Johnson"
-    },
-    {
-      "id": "carpentaria_shire_council/duane_amos",
-      "name": "Duane Amos"
-    },
-    {
-      "id": "cassowary_coast_regional_council/alister_pike",
-      "name": "Alister Pike"
-    },
-    {
-      "id": "cassowary_coast_regional_council/bill_shannon",
-      "name": "Bill Shannon"
-    },
-    {
-      "id": "cassowary_coast_regional_council/bryce_mcdonald",
-      "name": "Bryce McDonald"
-    },
-    {
-      "id": "cassowary_coast_regional_council/glenn_raleigh",
-      "name": "Glenn Raleigh"
-    },
-    {
-      "id": "cassowary_coast_regional_council/ian_rule",
-      "name": "Ian Rule"
-    },
-    {
-      "id": "cassowary_coast_regional_council/kylie_farinelli",
-      "name": "Kylie Farinelli"
-    },
-    {
-      "id": "cassowary_coast_regional_council/mark_nolan",
-      "name": "Mark Nolan"
-    },
-    {
-      "id": "charters_towers_regional_council/franklin_beveridge",
-      "name": "Franklin Beveridge"
-    },
-    {
-      "id": "charters_towers_regional_council/barbara_robinson",
-      "name": "Barbara Robinson"
-    },
-    {
-      "id": "charters_towers_regional_council/bernie_robertson",
-      "name": "Bernie Robertson"
-    },
-    {
-      "id": "charters_towers_regional_council/brian_beveridge",
-      "name": "Brian Beveridge"
-    },
-    {
-      "id": "charters_towers_regional_council/joe_cooper",
-      "name": "Joe Cooper"
-    },
-    {
-      "id": "charters_towers_regional_council/mervyn_(roma)_bailey",
-      "name": "Mervyn (Roma) Bailey"
-    },
-    {
-      "id": "charters_towers_regional_council/wally_brewer",
-      "name": "Wally Brewer"
-    },
-    {
-      "id": "cloncurry_shire_council/andrew_daniels",
-      "name": "Andrew Daniels"
-    },
-    {
-      "id": "cloncurry_shire_council/colin_ferguson",
-      "name": "Colin Ferguson"
-    },
-    {
-      "id": "cloncurry_shire_council/jane_mcmillan",
-      "name": "Jane McMillan"
-    },
-    {
-      "id": "cloncurry_shire_council/keith_douglas",
-      "name": "Keith Douglas"
-    },
-    {
-      "id": "cloncurry_shire_council/robert_mcdonald",
-      "name": "Robert McDonald"
-    },
-    {
-      "id": "cook_shire_council/peter_scott",
-      "name": "Peter Scott"
-    },
-    {
-      "id": "cook_shire_council/alan_wilson",
-      "name": "Alan Wilson"
-    },
-    {
-      "id": "cook_shire_council/glen_shephard",
-      "name": "Glen Shephard"
-    },
-    {
-      "id": "cook_shire_council/kaz_price",
-      "name": "Kaz Price"
-    },
-    {
-      "id": "cook_shire_council/penny_johnson",
-      "name": "Penny Johnson"
-    },
-    {
-      "id": "cook_shire_council/russell_bowman",
-      "name": "Russell Bowman"
-    },
-    {
-      "id": "cook_shire_council/sue_clark",
-      "name": "Sue Clark"
-    },
-    {
-      "id": "croydon_shire_council/trevor_pickering",
-      "name": "Trevor Pickering"
-    },
-    {
-      "id": "croydon_shire_council/kim_gaynor",
-      "name": "Kim Gaynor"
-    },
-    {
-      "id": "croydon_shire_council/john_pickering",
-      "name": "John Pickering"
-    },
-    {
-      "id": "croydon_shire_council/michelle_martin",
-      "name": "Michelle Martin"
-    },
-    {
-      "id": "croydon_shire_council/peter_kennedy",
-      "name": "Peter Kennedy"
-    },
-    {
-      "id": "doomadgee_aboriginal_shire_council/frederick_o'keefe",
-      "name": "Frederick O'Keefe"
-    },
-    {
-      "id": "doomadgee_aboriginal_shire_council/elaine_cairns",
-      "name": "Elaine Cairns"
-    },
-    {
-      "id": "doomadgee_aboriginal_shire_council/jason_ned",
-      "name": "Jason Ned"
-    },
-    {
-      "id": "doomadgee_aboriginal_shire_council/tony_douglas",
-      "name": "Tony Douglas"
-    },
-    {
-      "id": "doomadgee_aboriginal_shire_council/vernon_ned",
-      "name": "Vernon Ned"
-    },
-    {
-      "id": "etheridge_shire_council/will_attwood",
-      "name": "Will Attwood"
-    },
-    {
-      "id": "etheridge_shire_council/ian_tincknell",
-      "name": "Ian Tincknell"
-    },
-    {
-      "id": "etheridge_shire_council/pauline_royes",
-      "name": "Pauline Royes"
-    },
-    {
-      "id": "etheridge_shire_council/trevor_arnett",
-      "name": "Trevor Arnett"
-    },
-    {
-      "id": "etheridge_shire_council/warren_bethel",
-      "name": "Warren Bethel"
-    },
-    {
-      "id": "flinders_shire_council/greg_jones",
-      "name": "Greg Jones"
-    },
-    {
-      "id": "flinders_shire_council/authur_(bill)_bode",
-      "name": "Authur (Bill) Bode"
-    },
-    {
-      "id": "flinders_shire_council/barbara_geisler",
-      "name": "Barbara Geisler"
-    },
-    {
-      "id": "flinders_shire_council/jane_charuba",
-      "name": "Jane Charuba"
-    },
-    {
-      "id": "flinders_shire_council/ninian_stewart-moore",
-      "name": "Ninian Stewart-Moore"
-    },
-    {
-      "id": "flinders_shire_council/sean_o'neill",
-      "name": "Sean O'Neill"
-    },
-    {
-      "id": "flinders_shire_council/shane_mccarthy",
-      "name": "Shane McCarthy"
-    },
-    {
-      "id": "hinchinbrook_shire_council/mansell_(rodger)_bow",
-      "name": "Mansell (Rodger) Bow"
-    },
-    {
-      "id": "hinchinbrook_shire_council/david_carr",
-      "name": "David Carr"
-    },
-    {
-      "id": "hinchinbrook_shire_council/lawrence_molachino",
-      "name": "Lawrence Molachino"
-    },
-    {
-      "id": "hinchinbrook_shire_council/marc_tack",
-      "name": "Marc Tack"
-    },
-    {
-      "id": "hinchinbrook_shire_council/sherry_kaurila",
-      "name": "Sherry Kaurila"
-    },
-    {
-      "id": "hinchinbrook_shire_council/wallis_(wally)_skinner",
-      "name": "Wallis (Wally) Skinner"
-    },
-    {
-      "id": "hinchinbrook_shire_council/patrick_lynch",
-      "name": "Patrick Lynch"
-    },
-    {
-      "id": "hope_vale_aboriginal_shire_council/carmen_pearson",
-      "name": "Carmen Pearson"
-    },
-    {
-      "id": "hope_vale_aboriginal_shire_council/christopher_woibo",
-      "name": "Christopher Woibo"
-    },
-    {
-      "id": "hope_vale_aboriginal_shire_council/dwayne_bowen",
-      "name": "Dwayne Bowen"
-    },
-    {
-      "id": "hope_vale_aboriginal_shire_council/greg_mclean",
-      "name": "Greg McLean"
-    },
-    {
-      "id": "hope_vale_aboriginal_shire_council/june_pearson",
-      "name": "June Pearson"
-    },
-    {
-      "id": "kowanyama_aboriginal_shire_council/robert_holness",
-      "name": "Robert Holness"
-    },
-    {
-      "id": "kowanyama_aboriginal_shire_council/teddy_bernard",
-      "name": "Teddy Bernard"
-    },
-    {
-      "id": "kowanyama_aboriginal_shire_council/william_thomas",
-      "name": "William Thomas"
-    },
-    {
-      "id": "kowanyama_aboriginal_shire_council/michael_yam",
-      "name": "Michael Yam"
-    },
-    {
-      "id": "lockhart_river_aboriginal_shire_council/wayne_butcher",
-      "name": "Wayne Butcher"
-    },
-    {
-      "id": "lockhart_river_aboriginal_shire_council/norman_bally",
-      "name": "Norman Bally"
-    },
-    {
-      "id": "lockhart_river_aboriginal_shire_council/paul_piva",
-      "name": "Paul Piva"
-    },
-    {
-      "id": "lockhart_river_aboriginal_shire_council/rebecca_elu",
-      "name": "Rebecca Elu"
-    },
-    {
-      "id": "lockhart_river_aboriginal_shire_council/veronica_piva",
-      "name": "Veronica Piva"
-    },
-    {
-      "id": "mapoon_aboriginal_shire_council/peter_guivarra",
-      "name": "Peter Guivarra"
-    },
-    {
-      "id": "mapoon_aboriginal_shire_council/aileen_addo",
-      "name": "Aileen Addo"
-    },
-    {
-      "id": "mapoon_aboriginal_shire_council/beryl_woodley",
-      "name": "Beryl Woodley"
-    },
-    {
-      "id": "mapoon_aboriginal_shire_council/polly_smith",
-      "name": "Polly Smith"
-    },
-    {
-      "id": "mapoon_aboriginal_shire_council/ricky_guivarra",
-      "name": "Ricky Guivarra"
-    },
-    {
-      "id": "mckinlay_shire_council/belinda_murphy",
-      "name": "Belinda Murphy"
-    },
-    {
-      "id": "mckinlay_shire_council/anthony_batt",
-      "name": "Anthony Batt"
-    },
-    {
-      "id": "mckinlay_shire_council/edwina_hick",
-      "name": "Edwina Hick"
-    },
-    {
-      "id": "mckinlay_shire_council/neil_walker",
-      "name": "Neil Walker"
-    },
-    {
-      "id": "mckinlay_shire_council/philip_curr",
-      "name": "Philip Curr"
-    },
-    {
-      "id": "mornington_shire_council/bradley_wilson",
-      "name": "Bradley Wilson"
-    },
-    {
-      "id": "mornington_shire_council/bob_thompson",
-      "name": "Bob Thompson"
-    },
-    {
-      "id": "mornington_shire_council/jimmy_wilson",
-      "name": "Jimmy Wilson"
-    },
-    {
-      "id": "mornington_shire_council/robyrta_felton",
-      "name": "Robyrta Felton"
-    },
-    {
-      "id": "mornington_shire_council/sean_linden",
-      "name": "Sean Linden"
-    },
-    {
-      "id": "mount_isa_city_council/tony_mcgrady",
-      "name": "Tony McGrady"
-    },
-    {
-      "id": "mount_isa_city_council/anne_seymour",
-      "name": "Anne Seymour"
-    },
-    {
-      "id": "mount_isa_city_council/brett_peterson",
-      "name": "Brett Peterson"
-    },
-    {
-      "id": "mount_isa_city_council/george_fortune",
-      "name": "George Fortune"
-    },
-    {
-      "id": "mount_isa_city_council/jean_ferris",
-      "name": "Jean Ferris"
-    },
-    {
-      "id": "mount_isa_city_council/joyce_mccullock",
-      "name": "Joyce McCullock"
-    },
-    {
-      "id": "mount_isa_city_council/kim_coghlan",
-      "name": "Kim Coghlan"
-    },
-    {
-      "id": "napranum_aboriginal_shire_council/philemon_mene",
-      "name": "Philemon Mene"
-    },
-    {
-      "id": "napranum_aboriginal_shire_council/maryann_coconut",
-      "name": "Maryann Coconut"
-    },
-    {
-      "id": "napranum_aboriginal_shire_council/margie_adidi",
-      "name": "Margie Adidi"
-    },
-    {
-      "id": "napranum_aboriginal_shire_council/rex_burke",
-      "name": "Rex Burke"
-    },
-    {
-      "id": "napranum_aboriginal_shire_council/rhonda_charger",
-      "name": "Rhonda Charger"
-    },
-    {
-      "id": "northern_peninsula_area_regional_council/bernard_charlie",
-      "name": "Bernard Charlie"
-    },
-    {
-      "id": "northern_peninsula_area_regional_council/anthony_mara",
-      "name": "Anthony Mara"
-    },
-    {
-      "id": "northern_peninsula_area_regional_council/dennis_getawan",
-      "name": "Dennis Getawan"
-    },
-    {
-      "id": "northern_peninsula_area_regional_council/edward_newman",
-      "name": "Edward Newman"
-    },
-    {
-      "id": "northern_peninsula_area_regional_council/joseph_elu",
-      "name": "Joseph Elu"
-    },
-    {
-      "id": "northern_peninsula_area_regional_council/trevor_lifu",
-      "name": "Trevor Lifu"
-    },
-    {
-      "id": "palm_island_aboriginal_shire_council/alfred_lacey",
-      "name": "Alfred Lacey"
-    },
-    {
-      "id": "palm_island_aboriginal_shire_council/edward_walsh",
-      "name": "Edward Walsh"
-    },
-    {
-      "id": "palm_island_aboriginal_shire_council/frank_conway",
-      "name": "Frank Conway"
-    },
-    {
-      "id": "palm_island_aboriginal_shire_council/roy_prior",
-      "name": "Roy Prior"
-    },
-    {
-      "id": "palm_island_aboriginal_shire_council/sam_mislam",
-      "name": "Sam Mislam"
-    },
-    {
-      "id": "pormpuraaw_aboriginal_shire_council/richard_tarpencha",
-      "name": "Richard Tarpencha"
-    },
-    {
-      "id": "pormpuraaw_aboriginal_shire_council/dennis_michael",
-      "name": "Dennis Michael"
-    },
-    {
-      "id": "pormpuraaw_aboriginal_shire_council/lucy_foote",
-      "name": "Lucy Foote"
-    },
-    {
-      "id": "pormpuraaw_aboriginal_shire_council/patrick_gibuma",
-      "name": "Patrick Gibuma"
-    },
-    {
-      "id": "pormpuraaw_aboriginal_shire_council/toby_barney",
-      "name": "Toby Barney"
-    },
-    {
-      "id": "richmond_shire_council/john_wharton",
-      "name": "John Wharton"
-    },
-    {
-      "id": "richmond_shire_council/david_carter",
-      "name": "David Carter"
-    },
-    {
-      "id": "richmond_shire_council/june_kuhl",
-      "name": "June Kuhl"
-    },
-    {
-      "id": "richmond_shire_council/kevin_bawden",
-      "name": "Kevin Bawden"
-    },
-    {
-      "id": "richmond_shire_council/peter_ievers",
-      "name": "Peter Ievers"
-    },
-    {
-      "id": "richmond_shire_council/scott_geary",
-      "name": "Scott Geary"
-    },
-    {
-      "id": "richmond_shire_council/patsy-ann_fox",
-      "name": "Patsy-Ann Fox"
-    },
-    {
-      "id": "tablelands_regional_council/rosa_lee_long",
-      "name": "Rosa Lee Long"
-    },
-    {
-      "id": "tablelands_regional_council/geoff_stocker",
-      "name": "Geoff Stocker"
-    },
-    {
-      "id": "tablelands_regional_council/marjorie_pagani",
-      "name": "Marjorie Pagani"
-    },
-    {
-      "id": "tablelands_regional_council/peter_hodge",
-      "name": "Peter Hodge"
-    },
-    {
-      "id": "tablelands_regional_council/rod_marti",
-      "name": "Rod Marti"
-    },
-    {
-      "id": "tablelands_regional_council/shaaron_linwood",
-      "name": "Shaaron Linwood"
-    },
-    {
-      "id": "torres_shire_council/allan_ketchell",
-      "name": "Allan Ketchell"
-    },
-    {
-      "id": "torres_shire_council/john_abednego",
-      "name": "John Abednego"
-    },
-    {
-      "id": "torres_shire_council/napau_pedro_stephen",
-      "name": "Napau Pedro Stephen"
-    },
-    {
-      "id": "torres_shire_council/willie_wigness",
-      "name": "Willie Wigness"
-    },
-    {
-      "id": "torres_shire_council/yen_loban",
-      "name": "Yen Loban"
-    },
-    {
-      "id": "torres_strait_island_regional_council/fred_gela",
-      "name": "Fred Gela"
-    },
-    {
-      "id": "torres_strait_island_regional_council/david_bosun",
-      "name": "David Bosun"
-    },
-    {
-      "id": "torres_strait_island_regional_council/dimas_toby",
-      "name": "Dimas Toby"
-    },
-    {
-      "id": "torres_strait_island_regional_council/getano_lui",
-      "name": "Getano Lui"
-    },
-    {
-      "id": "torres_strait_island_regional_council/horace_baira",
-      "name": "Horace Baira"
-    },
-    {
-      "id": "torres_strait_island_regional_council/rocky_stephen",
-      "name": "Rocky Stephen"
-    },
-    {
-      "id": "torres_strait_island_regional_council/jimmy_gela",
-      "name": "Jimmy Gela"
-    },
-    {
-      "id": "torres_strait_island_regional_council/joel_gaiden",
-      "name": "Joel Gaiden"
-    },
-    {
-      "id": "torres_strait_island_regional_council/john_toshie_kris",
-      "name": "John Toshie Kris"
-    },
-    {
-      "id": "torres_strait_island_regional_council/keith_fell",
-      "name": "Keith Fell"
-    },
-    {
-      "id": "torres_strait_island_regional_council/mario_sabatino",
-      "name": "Mario Sabatino"
-    },
-    {
-      "id": "torres_strait_island_regional_council/phillemon_mosby",
-      "name": "Phillemon Mosby"
-    },
-    {
-      "id": "torres_strait_island_regional_council/ron_enosa",
-      "name": "Ron Enosa"
-    },
-    {
-      "id": "torres_strait_island_regional_council/ted_nai",
-      "name": "Ted Nai"
-    },
-    {
-      "id": "torres_strait_island_regional_council/willie_lui",
-      "name": "Willie Lui"
-    },
-    {
-      "email": "Mayor@townsville.qld.gov.au",
-      "id": "townsville_city_council/jenny_hill",
-      "image": "https://www.townsville.qld.gov.au/__data/assets/image/0021/3288/Image-of-Mayor-Jenny-Hill.jpg",
-      "name": "Jenny Hill",
-      "images": [
-        {
-          "url": "https://www.townsville.qld.gov.au/__data/assets/image/0021/3288/Image-of-Mayor-Jenny-Hill.jpg"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://www.townsville.qld.gov.au/about-council/mayor-and-councillors/councillor-profiles/cr-jenny-hill"
-        }
-      ]
-    },
-    {
-      "email": "colleen.doyle@townsville.qld.gov.au",
-      "id": "townsville_city_council/colleen_doyle",
-      "image": "https://www.townsville.qld.gov.au/__data/assets/image/0008/3302/colleen-doyle.png",
-      "name": "Colleen Doyle",
-      "images": [
-        {
-          "url": "https://www.townsville.qld.gov.au/__data/assets/image/0008/3302/colleen-doyle.png"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://www.townsville.qld.gov.au/about-council/mayor-and-councillors/councillor-profiles/cr-colleen-doyle"
-        }
-      ]
-    },
-    {
-      "email": "Russ.Cook@townsville.qld.gov.au",
-      "id": "townsville_city_council/russ_cook",
-      "image": "https://www.townsville.qld.gov.au/__data/assets/image/0029/12899/russ-cook.png",
-      "name": "Russ Cook",
-      "images": [
-        {
-          "url": "https://www.townsville.qld.gov.au/__data/assets/image/0029/12899/russ-cook.png"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://www.townsville.qld.gov.au/about-council/mayor-and-councillors/councillor-profiles/cr-russ-cook"
-        }
-      ]
-    },
-    {
-      "email": "Verena.Coombe@townsville.qld.gov.au",
-      "id": "townsville_city_council/verena_coombe",
-      "image": "https://www.townsville.qld.gov.au/__data/assets/image/0012/12900/verena-coombe.png",
-      "name": "Verena Coombe",
-      "images": [
-        {
-          "url": "https://www.townsville.qld.gov.au/__data/assets/image/0012/12900/verena-coombe.png"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://www.townsville.qld.gov.au/about-council/mayor-and-councillors/councillor-profiles/cr-verena-coombe"
-        }
-      ]
-    },
-    {
-      "email": "cr.les.walker@townsville.qld.gov.au",
-      "id": "townsville_city_council/les_walker",
-      "image": "https://www.townsville.qld.gov.au/__data/assets/image/0010/3313/les-walker.png",
-      "name": "Les Walker",
-      "images": [
-        {
-          "url": "https://www.townsville.qld.gov.au/__data/assets/image/0010/3313/les-walker.png"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://www.townsville.qld.gov.au/about-council/mayor-and-councillors/councillor-profiles/cr-les-walker"
-        }
-      ]
-    },
-    {
-      "email": "Kurt.Rehbein@townsville.qld.gov.au",
-      "id": "townsville_city_council/kurt_rehbein",
-      "image": "https://www.townsville.qld.gov.au/__data/assets/image/0024/12894/kurt-rehbein.png",
-      "name": "Kurt Rehbein",
-      "images": [
-        {
-          "url": "https://www.townsville.qld.gov.au/__data/assets/image/0024/12894/kurt-rehbein.png"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://www.townsville.qld.gov.au/about-council/mayor-and-councillors/councillor-profiles/cr-kurt-rehbein"
-        }
-      ]
-    },
-    {
-      "email": "Maurie.Soars@townsville.qld.gov.au",
-      "id": "townsville_city_council/maurie_soars",
-      "image": "https://www.townsville.qld.gov.au/__data/assets/image/0027/12897/maurie-soars.png",
-      "name": "Maurie Soars",
-      "images": [
-        {
-          "url": "https://www.townsville.qld.gov.au/__data/assets/image/0027/12897/maurie-soars.png"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://www.townsville.qld.gov.au/about-council/mayor-and-councillors/councillor-profiles/cr-maurie-soars"
-        }
-      ]
-    },
-    {
-      "email": "Mark.Molachino@townsville.qld.gov.au",
-      "id": "townsville_city_council/mark_molachino",
-      "image": "https://www.townsville.qld.gov.au/__data/assets/image/0026/12896/mark-molochino.png",
-      "name": "Mark Molachino",
-      "images": [
-        {
-          "url": "https://www.townsville.qld.gov.au/__data/assets/image/0026/12896/mark-molochino.png"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://www.townsville.qld.gov.au/about-council/mayor-and-councillors/councillor-profiles/cr-mark-molachino"
-        }
-      ]
-    },
-    {
-      "email": "Ann-Maree.Greaney@townsville.qld.gov.au",
-      "id": "townsville_city_council/ann-maree_greaney",
-      "image": "https://www.townsville.qld.gov.au/__data/assets/image/0023/12893/ann-maree-greaney.png",
-      "name": "Ann-Maree Greaney",
-      "images": [
-        {
-          "url": "https://www.townsville.qld.gov.au/__data/assets/image/0023/12893/ann-maree-greaney.png"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://www.townsville.qld.gov.au/about-council/mayor-and-councillors/councillor-profiles/cr-ann-maree-greaney"
-        }
-      ]
-    },
-    {
-      "email": "Paul.Jacob@townsville.qld.gov.au",
-      "id": "townsville_city_council/paul_jacob",
-      "image": "https://www.townsville.qld.gov.au/__data/assets/image/0028/12898/paul-jacob.png",
-      "name": "Paul Jacob",
-      "images": [
-        {
-          "url": "https://www.townsville.qld.gov.au/__data/assets/image/0028/12898/paul-jacob.png"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://www.townsville.qld.gov.au/about-council/mayor-and-councillors/councillor-profiles/cr-paul-jacob"
-        }
-      ]
-    },
-    {
-      "email": "Margie.Ryder@townsville.qld.gov.au",
-      "id": "townsville_city_council/margie_ryder",
-      "image": "https://www.townsville.qld.gov.au/__data/assets/image/0025/12895/margie-ryder.png",
-      "name": "Margie Ryder",
-      "images": [
-        {
-          "url": "https://www.townsville.qld.gov.au/__data/assets/image/0025/12895/margie-ryder.png"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://www.townsville.qld.gov.au/about-council/mayor-and-councillors/councillor-profiles/cr-margie-ryder"
-        }
-      ]
-    },
-    {
-      "id": "wujal_wujal_aboriginal_shire_council/clifford_harrigan",
-      "name": "Clifford Harrigan"
-    },
-    {
-      "id": "wujal_wujal_aboriginal_shire_council/allister_gibson",
-      "name": "Allister Gibson"
-    },
-    {
-      "id": "wujal_wujal_aboriginal_shire_council/natasha_duncan",
-      "name": "Natasha Duncan"
-    },
-    {
-      "id": "wujal_wujal_aboriginal_shire_council/vincent_tayley",
-      "name": "Vincent Tayley"
-    },
-    {
-      "id": "yarrabah_aboriginal_shire_council/errol_neal",
-      "name": "Errol Neal"
-    },
-    {
-      "id": "yarrabah_aboriginal_shire_council/bevan_walsh",
-      "name": "Bevan Walsh"
-    },
-    {
-      "id": "yarrabah_aboriginal_shire_council/henry_miller",
-      "name": "Henry Miller"
-    },
-    {
-      "id": "yarrabah_aboriginal_shire_council/malcolm_canendo",
-      "name": "Malcolm Canendo"
-    },
-    {
-      "id": "yarrabah_aboriginal_shire_council/mark_wilson",
-      "name": "Mark Wilson"
-    },
-    {
-      "id": "douglas_shire_council/julia_leu",
-      "name": "Julia Leu"
-    },
-    {
-      "id": "douglas_shire_council/david_carey",
-      "name": "David Carey"
-    },
-    {
-      "id": "douglas_shire_council/bruce_clarke",
-      "name": "Bruce Clarke"
-    },
-    {
-      "id": "douglas_shire_council/terry_melchert",
-      "name": "Terry Melchert"
-    },
-    {
-      "id": "douglas_shire_council/abigail_noli",
-      "name": "Abigail Noli"
-    },
-    {
-      "id": "mareeba_shire_council/tom_gilmore",
-      "name": "Tom Gilmore"
-    },
-    {
-      "id": "mareeba_shire_council/jenny_jensen",
-      "name": "Jenny Jensen"
-    },
-    {
-      "id": "mareeba_shire_council/alan_pederson",
-      "name": "Alan Pederson"
-    },
-    {
-      "id": "mareeba_shire_council/edward_(nipper)_brown",
-      "name": "Edward (Nipper) Brown"
-    },
-    {
-      "id": "mareeba_shire_council/karen_ewin",
-      "name": "Karen Ewin"
-    },
-    {
-      "id": "mareeba_shire_council/allan_holmes",
-      "name": "Allan Holmes"
-    },
-    {
-      "id": "mareeba_shire_council/mary_graham",
-      "name": "Mary Graham"
-    },
-    {
-      "id": "balonne_shire_council/donna_stewart",
-      "name": "Donna Stewart"
-    },
-    {
-      "id": "balonne_shire_council/fiona_gaske",
-      "name": "Fiona Gaske"
-    },
-    {
-      "id": "balonne_shire_council/ian_winks",
-      "name": "Ian Winks"
-    },
-    {
-      "id": "balonne_shire_council/joanne_kellock",
-      "name": "Joanne Kellock"
-    },
-    {
-      "id": "balonne_shire_council/richard_marsh",
-      "name": "Richard Marsh"
-    },
-    {
-      "id": "balonne_shire_council/robert_paul",
-      "name": "Robert Paul"
-    },
-    {
-      "id": "balonne_shire_council/rod_avery",
-      "name": "Rod Avery"
     },
     {
       "id": "brisbane_city_council/graham_quirk",
@@ -1451,6 +183,14 @@
     {
       "id": "brisbane_city_council/jarred_cassidy",
       "name": "Jarred Cassidy"
+    },
+    {
+      "id": "brisbane_city_council/angela_owen",
+      "name": "Angela Owen"
+    },
+    {
+      "id": "brisbane_city_council/charles_strunk",
+      "name": "Charles Strunk"
     },
     {
       "id": "brisbane_city_council/adrian_schrinner",
@@ -1477,8 +217,8 @@
       "name": "Fiona King"
     },
     {
-      "id": "brisbane_city_council/helen_abrahams",
-      "name": "Helen Abrahams"
+      "id": "brisbane_city_council/johnathan_sri",
+      "name": "Johnathan Sri"
     },
     {
       "id": "brisbane_city_council/ian_mckenzie",
@@ -1493,16 +233,16 @@
       "name": "Kim Marx"
     },
     {
-      "id": "brisbane_city_council/kim_flesser",
-      "name": "Kim Flesser"
+      "id": "brisbane_city_council/adam_allan",
+      "name": "Adam Allan"
     },
     {
       "id": "brisbane_city_council/krista_adams",
       "name": "Krista Adams"
     },
     {
-      "id": "brisbane_city_council/margaret_de_wit",
-      "name": "Margaret De Wit"
+      "id": "brisbane_city_council/kate_richards",
+      "name": "Kate Richards"
     },
     {
       "id": "brisbane_city_council/matthew_bourke",
@@ -1553,137 +293,781 @@
       "name": "John Ferguson"
     },
     {
-      "id": "bulloo_shire_council/bernard_brown",
-      "name": "Bernard Brown"
+      "id": "bulloo_shire_council/alison_petty",
+      "name": "Alison Petty"
     },
     {
-      "id": "bulloo_shire_council/doug_clifford",
-      "name": "Doug Clifford"
+      "id": "bulloo_shire_council/donna_humphris",
+      "name": "Donna Humphris"
+    },
+    {
+      "id": "bulloo_shire_council/shirley_girdler",
+      "name": "Shirley Girdler"
     },
     {
       "id": "bulloo_shire_council/john_cobb",
       "name": "John Cobb"
     },
     {
-      "id": "bulloo_shire_council/peter_degoumois",
-      "name": "Peter Degoumois"
+      "email": "jack.dempsey@bundaberg.qld.gov.au",
+      "id": "bundaberg_regional_council/jack_dempsey",
+      "name": "Jack Dempsey"
     },
     {
-      "id": "bundaberg_regional_council/mal_forman",
-      "name": "Mal Forman"
+      "email": "jason.bartels@bundaberg.qld.gov.au",
+      "id": "bundaberg_regional_council/jason_bartels",
+      "name": "Jason Bartels"
     },
     {
-      "id": "bundaberg_regional_council/alan_bush",
-      "name": "Alan Bush"
+      "email": "bill.trevor@bundaberg.qld.gov.au",
+      "id": "bundaberg_regional_council/william_(bill)_trevor",
+      "name": "William (Bill) Trevor"
     },
     {
-      "id": "bundaberg_regional_council/anthony_ricciardi",
-      "name": "Anthony Ricciardi"
+      "email": "helen.blackburn@bundaberg.qld.gov.au",
+      "id": "bundaberg_regional_council/helen_blackburn",
+      "name": "Helen Blackburn"
     },
     {
-      "id": "bundaberg_regional_council/danny_rowleson",
-      "name": "Danny Rowleson"
+      "email": "scott.rowleson@bundaberg.qld.gov.au",
+      "id": "bundaberg_regional_council/scott_rowleson",
+      "name": "Scott Rowleson"
     },
     {
+      "email": "peter.heuser@bundaberg.qld.gov.au",
+      "id": "bundaberg_regional_council/peter_heuser",
+      "name": "Peter Heuser"
+    },
+    {
+      "email": "david.batt@bundaberg.qld.gov.au",
       "id": "bundaberg_regional_council/david_batt",
-      "name": "David Batt"
+      "image": "http://www.bundaberg.qld.gov.au/files/images/councillors/Cr_David_Batt_0.jpg",
+      "name": "David Batt",
+      "images": [
+        {
+          "url": "http://www.bundaberg.qld.gov.au/files/images/councillors/Cr_David_Batt_0.jpg"
+        }
+      ]
     },
     {
+      "email": "greg.barnes@bundaberg.qld.gov.au",
       "id": "bundaberg_regional_council/gregory_barnes",
-      "name": "Gregory Barnes"
+      "image": "http://www.bundaberg.qld.gov.au/files/images/councillors/Cr_Greg_Barnes_0.jpg",
+      "name": "Gregory Barnes",
+      "images": [
+        {
+          "url": "http://www.bundaberg.qld.gov.au/files/images/councillors/Cr_Greg_Barnes_0.jpg"
+        }
+      ]
     },
     {
+      "email": "judy.peters@bundaberg.qld.gov.au",
       "id": "bundaberg_regional_council/judith_peters",
-      "name": "Judith Peters"
+      "image": "http://www.bundaberg.qld.gov.au/files/images/councillors/Cr_Judy_Peters.jpg",
+      "name": "Judith Peters",
+      "images": [
+        {
+          "url": "http://www.bundaberg.qld.gov.au/files/images/councillors/Cr_Judy_Peters.jpg"
+        }
+      ]
     },
     {
-      "id": "bundaberg_regional_council/lynette_forgan",
-      "name": "Lynette Forgan"
-    },
-    {
+      "email": "ross.sommerfeld@bundaberg.qld.gov.au",
       "id": "bundaberg_regional_council/ross_sommerfeld",
-      "name": "Ross Sommerfeld"
+      "image": "http://www.bundaberg.qld.gov.au/files/images/councillors/Cr_Ross_Sommerfeld_0.jpg",
+      "name": "Ross Sommerfeld",
+      "images": [
+        {
+          "url": "http://www.bundaberg.qld.gov.au/files/images/councillors/Cr_Ross_Sommerfeld_0.jpg"
+        }
+      ]
     },
     {
-      "id": "bundaberg_regional_council/vincent_habermann",
-      "name": "Vincent Habermann"
-    },
-    {
+      "email": "wayne.honor@bundaberg.qld.gov.au",
       "id": "bundaberg_regional_council/wayne_honor",
-      "name": "Wayne Honor"
+      "image": "http://www.bundaberg.qld.gov.au/files/images/councillors/Cr_Wayne_Honor.jpg",
+      "name": "Wayne Honor",
+      "images": [
+        {
+          "url": "http://www.bundaberg.qld.gov.au/files/images/councillors/Cr_Wayne_Honor.jpg"
+        }
+      ]
+    },
+    {
+      "id": "burdekin_shire_council/lyn_mclaughlin",
+      "name": "Lyn McLaughlin"
+    },
+    {
+      "id": "burdekin_shire_council/john_bonanno",
+      "name": "John Bonanno"
+    },
+    {
+      "id": "burdekin_shire_council/tony_goodard",
+      "name": "Tony Goodard"
+    },
+    {
+      "id": "burdekin_shire_council/sue_perry",
+      "name": "Sue Perry"
+    },
+    {
+      "id": "burdekin_shire_council/john_woods",
+      "name": "John Woods"
+    },
+    {
+      "id": "burdekin_shire_council/ted_bawden",
+      "name": "Ted Bawden"
+    },
+    {
+      "id": "burdekin_shire_council/uli_liessmann",
+      "name": "Uli Liessmann"
+    },
+    {
+      "id": "burke_shire_council/ernie_camp",
+      "name": "Ernie Camp"
+    },
+    {
+      "id": "burke_shire_council/john_clarke",
+      "name": "John Clarke"
+    },
+    {
+      "id": "burke_shire_council/john_yanner",
+      "name": "John Yanner"
+    },
+    {
+      "id": "burke_shire_council/paul_poole",
+      "name": "Paul Poole"
+    },
+    {
+      "id": "burke_shire_council/tonya_murray",
+      "name": "Tonya Murray"
+    },
+    {
+      "email": "b.manning@cairns.qld.gov.au",
+      "id": "cairns_regional_council/bob_manning",
+      "image": "http://www.cairns.qld.gov.au/__data/assets/image/0006/53862/Bob-Manning-Mayor-lowres.jpg",
+      "name": "Bob Manning",
+      "images": [
+        {
+          "url": "http://www.cairns.qld.gov.au/__data/assets/image/0006/53862/Bob-Manning-Mayor-lowres.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.cairns.qld.gov.au/council/mayor-and-councillors/mayor"
+        }
+      ]
+    },
+    {
+      "email": "b.moller@cairns.qld.gov.au",
+      "id": "cairns_regional_council/brett_moller",
+      "image": "http://www.cairns.qld.gov.au/__data/assets/image/0007/53863/Brett-Moller-Div-1-lowres.jpg",
+      "name": "Brett Moller",
+      "images": [
+        {
+          "url": "http://www.cairns.qld.gov.au/__data/assets/image/0007/53863/Brett-Moller-Div-1-lowres.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.cairns.qld.gov.au/council/mayor-and-councillors/division-1"
+        }
+      ]
+    },
+    {
+      "email": "j.schilling@cairns.qld.gov.au",
+      "id": "cairns_regional_council/john_schilling",
+      "image": "http://www.cairns.qld.gov.au/__data/assets/image/0008/53864/John-Schilling-Div-2-lowres.jpg",
+      "name": "John Schilling",
+      "images": [
+        {
+          "url": "http://www.cairns.qld.gov.au/__data/assets/image/0008/53864/John-Schilling-Div-2-lowres.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.cairns.qld.gov.au/council/mayor-and-councillors/division-2"
+        }
+      ]
+    },
+    {
+      "email": "C.Zeiger@cairns.qld.gov.au",
+      "id": "cairns_regional_council/cathy_zeiger",
+      "image": "http://www.cairns.qld.gov.au/__data/assets/image/0017/132236/cathyzeiger.jpg",
+      "name": "Cathy Zeiger",
+      "images": [
+        {
+          "url": "http://www.cairns.qld.gov.au/__data/assets/image/0017/132236/cathyzeiger.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.cairns.qld.gov.au/council/mayor-and-councillors/division-3"
+        }
+      ]
+    },
+    {
+      "email": "t.james@cairns.qld.gov.au",
+      "id": "cairns_regional_council/terry_james",
+      "image": "http://www.cairns.qld.gov.au/__data/assets/image/0010/53866/Terry-James-Div-4-lowres.jpg",
+      "name": "Terry James",
+      "images": [
+        {
+          "url": "http://www.cairns.qld.gov.au/__data/assets/image/0010/53866/Terry-James-Div-4-lowres.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.cairns.qld.gov.au/council/mayor-and-councillors/division-4"
+        }
+      ]
+    },
+    {
+      "email": "r.bates@cairns.qld.gov.au",
+      "id": "cairns_regional_council/richie_bates",
+      "image": "http://www.cairns.qld.gov.au/__data/assets/image/0011/53867/Richie-Bates-Div-5-lowres.jpg",
+      "name": "Richie Bates",
+      "images": [
+        {
+          "url": "http://www.cairns.qld.gov.au/__data/assets/image/0011/53867/Richie-Bates-Div-5-lowres.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.cairns.qld.gov.au/council/mayor-and-councillors/division-5"
+        }
+      ]
+    },
+    {
+      "email": "l.cooper@cairns.qld.gov.au",
+      "id": "cairns_regional_council/linda_cooper",
+      "image": "http://www.cairns.qld.gov.au/__data/assets/image/0003/53868/web6-LCooper.jpg",
+      "name": "Linda Cooper",
+      "images": [
+        {
+          "url": "http://www.cairns.qld.gov.au/__data/assets/image/0003/53868/web6-LCooper.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.cairns.qld.gov.au/council/mayor-and-councillors/division-6"
+        }
+      ]
+    },
+    {
+      "email": "m.ohalloran@cairns.qld.gov.au",
+      "id": "cairns_regional_council/max_o'halloran",
+      "image": "http://www.cairns.qld.gov.au/__data/assets/image/0004/53869/Max-OHalloran-Div-7-lowres.jpg",
+      "name": "Max O'Halloran",
+      "images": [
+        {
+          "url": "http://www.cairns.qld.gov.au/__data/assets/image/0004/53869/Max-OHalloran-Div-7-lowres.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.cairns.qld.gov.au/council/mayor-and-councillors/division-7"
+        }
+      ]
+    },
+    {
+      "email": "j.richardson@cairns.qld.gov.au",
+      "id": "cairns_regional_council/jessie_richardson",
+      "image": "http://www.cairns.qld.gov.au/__data/assets/image/0006/53871/Jessie-Richardson-Div-8-lowres.jpg",
+      "name": "Jessie Richardson",
+      "images": [
+        {
+          "url": "http://www.cairns.qld.gov.au/__data/assets/image/0006/53871/Jessie-Richardson-Div-8-lowres.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.cairns.qld.gov.au/council/mayor-and-councillors/division-8"
+        }
+      ]
+    },
+    {
+      "email": "b.olds@cairns.qld.gov.au",
+      "id": "cairns_regional_council/brett_olds",
+      "name": "Brett Olds",
+      "sources": [
+        {
+          "url": "http://www.cairns.qld.gov.au/council/mayor-and-councillors/division-9"
+        }
+      ]
+    },
+    {
+      "id": "carpentaria_shire_council/lyall_(jack)_bawden",
+      "name": "Lyall (Jack) Bawden"
+    },
+    {
+      "id": "carpentaria_shire_council/andrew_murphy",
+      "name": "Andrew Murphy"
+    },
+    {
+      "id": "carpentaria_shire_council/bradley_hawkins",
+      "name": "Bradley Hawkins"
+    },
+    {
+      "id": "carpentaria_shire_council/peter_wells",
+      "name": "Peter Wells"
+    },
+    {
+      "id": "carpentaria_shire_council/james_(craig)_young",
+      "name": "James (Craig) Young"
+    },
+    {
+      "id": "carpentaria_shire_council/ashley_gallagher",
+      "name": "Ashley Gallagher"
+    },
+    {
+      "id": "carpentaria_shire_council/john_beard",
+      "name": "John Beard"
+    },
+    {
+      "id": "cassowary_coast_regional_council/john_kremastos",
+      "name": "John Kremastos"
+    },
+    {
+      "id": "cassowary_coast_regional_council/rick_taylor",
+      "name": "Rick Taylor"
+    },
+    {
+      "id": "cassowary_coast_regional_council/wayne_kimberley",
+      "name": "Wayne Kimberley"
+    },
+    {
+      "id": "cassowary_coast_regional_council/jeffrey_baines",
+      "name": "Jeffrey Baines"
+    },
+    {
+      "id": "cassowary_coast_regional_council/ben_heath",
+      "name": "Ben Heath"
+    },
+    {
+      "id": "cassowary_coast_regional_council/glenn_raleigh",
+      "name": "Glenn Raleigh"
+    },
+    {
+      "id": "cassowary_coast_regional_council/mark_nolan",
+      "name": "Mark Nolan"
+    },
+    {
+      "id": "central_highlands_regional_council/kerry_hayes",
+      "name": "Kerry Hayes"
+    },
+    {
+      "id": "central_highlands_regional_council/megan_daniels",
+      "name": "Megan Daniels"
+    },
+    {
+      "id": "central_highlands_regional_council/david_lacey",
+      "name": "David Lacey"
+    },
+    {
+      "id": "central_highlands_regional_council/alan_mcindoe",
+      "name": "Alan McIndoe"
+    },
+    {
+      "id": "central_highlands_regional_council/christine_rolfe",
+      "name": "Christine Rolfe"
+    },
+    {
+      "id": "central_highlands_regional_council/charlie_brimblecombe",
+      "name": "Charlie Brimblecombe"
+    },
+    {
+      "id": "central_highlands_regional_council/gail_godwin-smith",
+      "name": "Gail Godwin-Smith"
+    },
+    {
+      "id": "central_highlands_regional_council/gail_nixon",
+      "name": "Gail Nixon"
+    },
+    {
+      "id": "central_highlands_regional_council/paul_bell",
+      "name": "Paul Bell"
+    },
+    {
+      "id": "charters_towers_regional_council/liz_schmidt",
+      "name": "Liz Schmidt"
+    },
+    {
+      "id": "charters_towers_regional_council/alan_barr",
+      "name": "Alan Barr"
+    },
+    {
+      "id": "charters_towers_regional_council/graham_lohmann",
+      "name": "Graham Lohmann"
+    },
+    {
+      "id": "charters_towers_regional_council/brett_maff",
+      "name": "Brett Maff"
+    },
+    {
+      "id": "charters_towers_regional_council/mike_power",
+      "name": "Mike Power"
+    },
+    {
+      "id": "charters_towers_regional_council/sonia_bennetto",
+      "name": "Sonia Bennetto"
+    },
+    {
+      "id": "charters_towers_regional_council/mervyn_(roma)_bailey",
+      "name": "Mervyn (Roma) Bailey"
     },
     {
       "id": "cherbourg_aboriginal_shire_council/kenny_bone",
       "name": "Kenny Bone"
     },
     {
-      "id": "cherbourg_aboriginal_shire_council/christine_stewart",
-      "name": "Christine Stewart"
+      "id": "cherbourg_aboriginal_shire_council/alana_purcell",
+      "name": "Alana Purcell"
     },
     {
-      "id": "cherbourg_aboriginal_shire_council/gordon_wragge",
-      "name": "Gordon Wragge"
+      "id": "cherbourg_aboriginal_shire_council/james_saltner",
+      "name": "James Saltner"
     },
     {
-      "id": "cherbourg_aboriginal_shire_council/rory_boney",
-      "name": "Rory Boney"
+      "id": "cherbourg_aboriginal_shire_council/elvie_sandow",
+      "name": "Elvie Sandow"
     },
     {
-      "id": "cherbourg_aboriginal_shire_council/arnold_murray",
-      "name": "Arnold Murray"
+      "id": "cherbourg_aboriginal_shire_council/tom_langton",
+      "name": "Tom Langton"
     },
     {
-      "id": "fraser_coast_regional_council/gerard_o'connell",
-      "name": "Gerard O'Connell"
+      "id": "cloncurry_shire_council/gregory_campbell",
+      "name": "Gregory Campbell"
     },
     {
+      "id": "cloncurry_shire_council/damien_mcgee",
+      "name": "Damien McGee"
+    },
+    {
+      "id": "cloncurry_shire_council/brad_rix",
+      "name": "Brad Rix"
+    },
+    {
+      "id": "cloncurry_shire_council/dane_swalling",
+      "name": "Dane Swalling"
+    },
+    {
+      "id": "cook_shire_council/peter_scott",
+      "name": "Peter Scott"
+    },
+    {
+      "id": "cook_shire_council/john_dessmann",
+      "name": "John Dessmann"
+    },
+    {
+      "id": "cook_shire_council/john_giese",
+      "name": "John Giese"
+    },
+    {
+      "id": "cook_shire_council/larissa_hale",
+      "name": "Larissa Hale"
+    },
+    {
+      "id": "cook_shire_council/robyn_holmes",
+      "name": "Robyn Holmes"
+    },
+    {
+      "id": "cook_shire_council/alan_wilson",
+      "name": "Alan Wilson"
+    },
+    {
+      "id": "cook_shire_council/kaz_price",
+      "name": "Kaz Price"
+    },
+    {
+      "id": "croydon_shire_council/trevor_pickering",
+      "name": "Trevor Pickering"
+    },
+    {
+      "id": "croydon_shire_council/kim_gaynor",
+      "name": "Kim Gaynor"
+    },
+    {
+      "id": "croydon_shire_council/wayne_bing_chew",
+      "name": "Wayne Bing Chew"
+    },
+    {
+      "id": "croydon_shire_council/jim_gilmartin",
+      "name": "Jim Gilmartin"
+    },
+    {
+      "id": "croydon_shire_council/jeffrey_norman",
+      "name": "Jeffrey Norman"
+    },
+    {
+      "id": "diamantina_shire_council/geoff_morton",
+      "name": "Geoff Morton"
+    },
+    {
+      "id": "diamantina_shire_council/doug_cooms",
+      "name": "Doug Cooms"
+    },
+    {
+      "id": "diamantina_shire_council/bev_maunsell",
+      "name": "Bev Maunsell"
+    },
+    {
+      "id": "diamantina_shire_council/don_rayment",
+      "name": "Don Rayment"
+    },
+    {
+      "id": "diamantina_shire_council/stephen_cramer",
+      "name": "Stephen Cramer"
+    },
+    {
+      "id": "doomadgee_aboriginal_shire_council/edric_walden",
+      "name": "Edric Walden"
+    },
+    {
+      "id": "doomadgee_aboriginal_shire_council/tony_chong",
+      "name": "Tony Chong"
+    },
+    {
+      "id": "doomadgee_aboriginal_shire_council/dean_jupiter",
+      "name": "Dean Jupiter"
+    },
+    {
+      "id": "doomadgee_aboriginal_shire_council/scharrayne_foster",
+      "name": "Scharrayne Foster"
+    },
+    {
+      "id": "doomadgee_aboriginal_shire_council/jason_ned",
+      "name": "Jason Ned"
+    },
+    {
+      "id": "douglas_shire_council/michael_kerr",
+      "name": "Michael Kerr"
+    },
+    {
+      "id": "douglas_shire_council/roy_zammataro",
+      "name": "Roy Zammataro"
+    },
+    {
+      "id": "douglas_shire_council/julia_leu",
+      "name": "Julia Leu"
+    },
+    {
+      "id": "douglas_shire_council/david_carey",
+      "name": "David Carey"
+    },
+    {
+      "id": "douglas_shire_council/abigail_noli",
+      "name": "Abigail Noli"
+    },
+    {
+      "id": "etheridge_shire_council/warren_devlin",
+      "name": "Warren Devlin"
+    },
+    {
+      "id": "etheridge_shire_council/troy_barnes",
+      "name": "Troy Barnes"
+    },
+    {
+      "id": "etheridge_shire_council/tony_gallagher",
+      "name": "Tony Gallagher"
+    },
+    {
+      "id": "etheridge_shire_council/warren_bethel",
+      "name": "Warren Bethel"
+    },
+    {
+      "id": "etheridge_shire_council/will_attwood",
+      "name": "Will Attwood"
+    },
+    {
+      "id": "flinders_shire_council/jane_mcnamara",
+      "name": "Jane McNamara"
+    },
+    {
+      "id": "flinders_shire_council/kelly_carter",
+      "name": "Kelly Carter"
+    },
+    {
+      "id": "flinders_shire_council/graham_sealy",
+      "name": "Graham Sealy"
+    },
+    {
+      "id": "flinders_shire_council/kate_downie",
+      "name": "Kate Downie"
+    },
+    {
+      "id": "flinders_shire_council/authur_(bill)_bode",
+      "name": "Authur (Bill) Bode"
+    },
+    {
+      "id": "flinders_shire_council/sean_o'neill",
+      "name": "Sean O'Neill"
+    },
+    {
+      "email": "chris.loft@frasercoast.qld.gov.au",
       "id": "fraser_coast_regional_council/chris_loft",
-      "name": "Chris Loft"
-    },
-    {
-      "id": "fraser_coast_regional_council/daniel_sanderson",
-      "name": "Daniel Sanderson"
-    },
-    {
-      "id": "fraser_coast_regional_council/darren_everard",
-      "name": "Darren Everard"
-    },
-    {
-      "id": "fraser_coast_regional_council/george_seymour",
-      "name": "George Seymour"
-    },
-    {
-      "id": "fraser_coast_regional_council/james_hansen",
-      "name": "James Hansen"
-    },
-    {
-      "id": "fraser_coast_regional_council/phil_truscott",
-      "name": "Phil Truscott"
-    },
-    {
-      "id": "fraser_coast_regional_council/robert_garland",
-      "name": "Robert Garland"
-    },
-    {
-      "id": "fraser_coast_regional_council/rolf_light",
-      "name": "Rolf Light"
-    },
-    {
-      "id": "fraser_coast_regional_council/stuart_taylor",
-      "name": "Stuart Taylor"
-    },
-    {
-      "id": "fraser_coast_regional_council/trevor_mcdonald",
-      "name": "Trevor McDonald"
-    },
-    {
-      "email": "mayor@goldcoast.qld.gov.au",
-      "id": "gold_coast_city_council/tom_tate",
-      "image": "http://www.goldcoast.qld.gov.au/_images/Mayor-Tom-Tate-hs.jpg",
-      "name": "Tom Tate",
+      "image": "http://www.frasercoast.qld.gov.au/documents/4362881/41221396/Chris%20Loft%20-%20thumbnail?t=1461195729792%20Browse%20Server",
+      "name": "Chris Loft",
       "images": [
         {
-          "url": "http://www.goldcoast.qld.gov.au/_images/Mayor-Tom-Tate-hs.jpg"
+          "url": "http://www.frasercoast.qld.gov.au/documents/4362881/41221396/Chris%20Loft%20-%20thumbnail?t=1461195729792%20Browse%20Server"
+        }
+      ]
+    },
+    {
+      "email": "anne.maddern@frasercoast.qld.gov.au",
+      "id": "fraser_coast_regional_council/anne_maddern",
+      "image": "http://www.frasercoast.qld.gov.au/documents/4362881/9d7517fa-f699-41ad-9789-cb13097adcb9",
+      "name": "Anne Maddern",
+      "images": [
+        {
+          "url": "http://www.frasercoast.qld.gov.au/documents/4362881/9d7517fa-f699-41ad-9789-cb13097adcb9"
+        }
+      ]
+    },
+    {
+      "email": "paul.truscott@frasercoast.qld.gov.au",
+      "id": "fraser_coast_regional_council/paul_truscott",
+      "image": "http://www.frasercoast.qld.gov.au/documents/4362881/d00c6df1-6e32-4bba-96c3-b500f2d73b84",
+      "name": "Paul Truscott",
+      "images": [
+        {
+          "url": "http://www.frasercoast.qld.gov.au/documents/4362881/d00c6df1-6e32-4bba-96c3-b500f2d73b84"
+        }
+      ]
+    },
+    {
+      "email": "david.lewis@frasercoast.qld.gov.au",
+      "id": "fraser_coast_regional_council/david_lewis",
+      "image": "http://www.frasercoast.qld.gov.au/documents/4362881/41221396/David%20Lewis%20-%20thumbnail.jpg?t=1461199807891",
+      "name": "David Lewis",
+      "images": [
+        {
+          "url": "http://www.frasercoast.qld.gov.au/documents/4362881/41221396/David%20Lewis%20-%20thumbnail.jpg?t=1461199807891"
+        }
+      ]
+    },
+    {
+      "email": "denis.chapman@frasercoast.qld.gov.au",
+      "id": "fraser_coast_regional_council/denis_chapman",
+      "image": "http://www.frasercoast.qld.gov.au/documents/4362881/e2ef42c5-fa1b-4644-8c7e-62d0f424f630",
+      "name": "Denis Chapman",
+      "images": [
+        {
+          "url": "http://www.frasercoast.qld.gov.au/documents/4362881/e2ef42c5-fa1b-4644-8c7e-62d0f424f630"
+        }
+      ]
+    },
+    {
+      "email": "daniel.sanderson@frasercoast.qld.gov.au",
+      "id": "fraser_coast_regional_council/daniel_sanderson",
+      "image": "http://www.frasercoast.qld.gov.au/documents/4362881/e2912d22-096a-40dc-a9c5-d309d9acb0fa",
+      "name": "Daniel Sanderson",
+      "images": [
+        {
+          "url": "http://www.frasercoast.qld.gov.au/documents/4362881/e2912d22-096a-40dc-a9c5-d309d9acb0fa"
+        }
+      ]
+    },
+    {
+      "email": "darren.everard@frasercoast.qld.gov.au",
+      "id": "fraser_coast_regional_council/darren_everard",
+      "image": "http://www.frasercoast.qld.gov.au/documents/4362881/1e764d4d-04a9-41bd-9fb6-922b4c3ce50d",
+      "name": "Darren Everard",
+      "images": [
+        {
+          "url": "http://www.frasercoast.qld.gov.au/documents/4362881/1e764d4d-04a9-41bd-9fb6-922b4c3ce50d"
+        }
+      ]
+    },
+    {
+      "email": "george.seymour@frasercoast.qld.gov.au",
+      "id": "fraser_coast_regional_council/george_seymour",
+      "image": "http://www.frasercoast.qld.gov.au/documents/4362881/41221396/George%20Seymour%20-%20thumbnail?t=1461199323529",
+      "name": "George Seymour",
+      "images": [
+        {
+          "url": "http://www.frasercoast.qld.gov.au/documents/4362881/41221396/George%20Seymour%20-%20thumbnail?t=1461199323529"
+        }
+      ]
+    },
+    {
+      "email": "james.hansen@frasercoast.qld.gov.au",
+      "id": "fraser_coast_regional_council/james_hansen",
+      "image": "http://www.frasercoast.qld.gov.au/documents/4362881/234178b5-1661-4a56-af23-1227f9263756",
+      "name": "James Hansen",
+      "images": [
+        {
+          "url": "http://www.frasercoast.qld.gov.au/documents/4362881/234178b5-1661-4a56-af23-1227f9263756"
+        }
+      ]
+    },
+    {
+      "email": "rolf.light@frasercoast.qld.gov.au",
+      "id": "fraser_coast_regional_council/rolf_light",
+      "image": "http://www.frasercoast.qld.gov.au/documents/4362881/41221396/Rolf%20Light%20-%20thumbnail?t=1461198217825",
+      "name": "Rolf Light",
+      "images": [
+        {
+          "url": "http://www.frasercoast.qld.gov.au/documents/4362881/41221396/Rolf%20Light%20-%20thumbnail?t=1461198217825"
+        }
+      ]
+    },
+    {
+      "email": "stuart.taylor@frasercoast.qld.gov.au",
+      "id": "fraser_coast_regional_council/stuart_taylor",
+      "image": "http://www.frasercoast.qld.gov.au/documents/4362881/fcd1eb79-5e9e-4dfb-90b6-e2b04ce11d3e",
+      "name": "Stuart Taylor",
+      "images": [
+        {
+          "url": "http://www.frasercoast.qld.gov.au/documents/4362881/fcd1eb79-5e9e-4dfb-90b6-e2b04ce11d3e"
+        }
+      ]
+    },
+    {
+      "id": "gladstone_regional_council/matt_burnett",
+      "name": "Matt Burnett"
+    },
+    {
+      "id": "gladstone_regional_council/cindi_bush",
+      "name": "Cindi Bush"
+    },
+    {
+      "id": "gladstone_regional_council/glen_churchill",
+      "name": "Glen Churchill"
+    },
+    {
+      "id": "gladstone_regional_council/kahn_goodluck",
+      "name": "Kahn Goodluck"
+    },
+    {
+      "id": "gladstone_regional_council/peter_masters",
+      "name": "Peter Masters"
+    },
+    {
+      "id": "gladstone_regional_council/desley_o'grady",
+      "name": "Desley O'Grady"
+    },
+    {
+      "id": "gladstone_regional_council/chris_(ct)_trevor",
+      "name": "Chris (CT) Trevor"
+    },
+    {
+      "id": "gladstone_regional_council/rick_hansen",
+      "name": "Rick Hansen"
+    },
+    {
+      "id": "gladstone_regional_council/pj_sobhanian",
+      "name": "PJ Sobhanian"
+    },
+    {
+      "email": "division1@goldcoast.qld.gov.au",
+      "id": "gold_coast_city_council/donna_gates",
+      "image": "http://www.goldcoast.qld.gov.au/_images/Cr-Gates-hs.jpg",
+      "name": "Donna Gates",
+      "images": [
+        {
+          "url": "http://www.goldcoast.qld.gov.au/_images/Cr-Gates-hs.jpg"
         }
       ],
       "sources": [
@@ -1693,13 +1077,70 @@
       ]
     },
     {
-      "email": "division8@goldcoast.qld.gov.au",
-      "id": "gold_coast_city_council/bob_la_castra",
-      "image": "http://www.goldcoast.qld.gov.au/_images/Cr-Bob-La-Castra-hs.jpg",
-      "name": "Bob La Castra",
+      "email": "division10@goldcoast.qld.gov.au",
+      "id": "gold_coast_city_council/paul_taylor",
+      "image": "http://www.goldcoast.qld.gov.au/_images/Cr-Paul-Taylor-hs.jpg",
+      "name": "Paul Taylor",
       "images": [
         {
-          "url": "http://www.goldcoast.qld.gov.au/_images/Cr-Bob-La-Castra-hs.jpg"
+          "url": "http://www.goldcoast.qld.gov.au/_images/Cr-Paul-Taylor-hs.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.goldcoast.qld.gov.au/council/councillors-divisions-209.html"
+        }
+      ]
+    },
+    {
+      "email": "division11@goldcoast.qld.gov.au",
+      "id": "gold_coast_city_council/herman_vorster",
+      "name": "Herman Vorster"
+    },
+    {
+      "email": "division12@goldcoast.qld.gov.au",
+      "id": "gold_coast_city_council/pauline_young",
+      "name": "Pauline Young",
+      "sources": [
+        {
+          "url": "http://www.goldcoast.qld.gov.au/council/councillors-divisions-209.html"
+        }
+      ]
+    },
+    {
+      "email": "division13@goldcoast.qld.gov.au",
+      "id": "gold_coast_city_council/daphne_mcdonald",
+      "image": "http://www.goldcoast.qld.gov.au/_images/Cr-Daphne-McDonald-hs.jpg",
+      "name": "Daphne McDonald",
+      "images": [
+        {
+          "url": "http://www.goldcoast.qld.gov.au/_images/Cr-Daphne-McDonald-hs.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.goldcoast.qld.gov.au/council/councillors-divisions-209.html"
+        }
+      ]
+    },
+    {
+      "email": "division14@goldcoast.qld.gov.au",
+      "id": "gold_coast_city_council/gail_o'neill",
+      "name": "Gail O'Neill",
+      "sources": [
+        {
+          "url": "http://www.goldcoast.qld.gov.au/council/councillors-divisions-209.html"
+        }
+      ]
+    },
+    {
+      "email": "division2@goldcoast.qld.gov.au",
+      "id": "gold_coast_city_council/william_owen-jones",
+      "image": "http://www.goldcoast.qld.gov.au/_images/Cr-William-Owen-Jones-hs.jpg",
+      "name": "William Owen-Jones",
+      "images": [
+        {
+          "url": "http://www.goldcoast.qld.gov.au/_images/Cr-William-Owen-Jones-hs.jpg"
         }
       ],
       "sources": [
@@ -1726,7 +1167,7 @@
     },
     {
       "email": "division4@goldcoast.qld.gov.au",
-      "id": "gold_coast_city_council/chris_robbins",
+      "id": "gold_coast_city_council/kristyn_boulton",
       "name": "Kristyn Boulton",
       "sources": [
         {
@@ -1735,15 +1176,9 @@
       ]
     },
     {
-      "email": "division13@goldcoast.qld.gov.au",
-      "id": "gold_coast_city_council/daphne_mcdonald",
-      "image": "http://www.goldcoast.qld.gov.au/_images/Cr-Daphne-McDonald-hs.jpg",
-      "name": "Daphne McDonald",
-      "images": [
-        {
-          "url": "http://www.goldcoast.qld.gov.au/_images/Cr-Daphne-McDonald-hs.jpg"
-        }
-      ],
+      "email": "division5@goldcoast.qld.gov.au",
+      "id": "gold_coast_city_council/peter_young",
+      "name": "Peter Young",
       "sources": [
         {
           "url": "http://www.goldcoast.qld.gov.au/council/councillors-divisions-209.html"
@@ -1751,29 +1186,18 @@
       ]
     },
     {
-      "email": "gbrown@goldcoast.qld.gov.au",
-      "id": "gold_coast_city_council/dawn_crichlow",
-      "image": "http://www.goldcoast.qld.gov.au/_images/Cr-Dawn-Crichlow-hs.jpg",
-      "name": "Dawn Crichlow",
-      "images": [
-        {
-          "url": "http://www.goldcoast.qld.gov.au/_images/Cr-Dawn-Crichlow-hs.jpg"
-        }
-      ],
-      "sources": [
-        {
-          "url": "http://www.goldcoast.qld.gov.au/council/councillors-divisions-209.html"
-        }
-      ]
+      "email": "division7@goldcoast.qld.gov.au",
+      "id": "gold_coast_city_council/gary_baildon",
+      "name": "Gary Baildon"
     },
     {
-      "email": "division1@goldcoast.qld.gov.au",
-      "id": "gold_coast_city_council/donna_gates",
-      "image": "http://www.goldcoast.qld.gov.au/_images/Cr-Gates-hs.jpg",
-      "name": "Donna Gates",
+      "email": "division8@goldcoast.qld.gov.au",
+      "id": "gold_coast_city_council/bob_la_castra",
+      "image": "http://www.goldcoast.qld.gov.au/_images/Cr-Bob-La-Castra-hs.jpg",
+      "name": "Bob La Castra",
       "images": [
         {
-          "url": "http://www.goldcoast.qld.gov.au/_images/Cr-Gates-hs.jpg"
+          "url": "http://www.goldcoast.qld.gov.au/_images/Cr-Bob-La-Castra-hs.jpg"
         }
       ],
       "sources": [
@@ -1799,53 +1223,13 @@
       ]
     },
     {
-      "email": "division5@goldcoast.qld.gov.au",
-      "id": "gold_coast_city_council/greg_betts",
-      "name": "Peter Young",
-      "sources": [
-        {
-          "url": "http://www.goldcoast.qld.gov.au/council/councillors-divisions-209.html"
-        }
-      ]
-    },
-    {
-      "email": "division7@goldcoast.qld.gov.au",
-      "id": "gold_coast_city_council/jan_grew",
-      "name": "Gary Baildon AM",
-      "sources": [
-        {
-          "url": "http://www.goldcoast.qld.gov.au/council/councillors-divisions-209.html"
-        }
-      ]
-    },
-    {
-      "email": "division11@goldcoast.qld.gov.au",
-      "id": "gold_coast_city_council/lex_bell",
-      "name": "Hermann Vorrster",
-      "sources": [
-        {
-          "url": "http://www.goldcoast.qld.gov.au/council/councillors-divisions-209.html"
-        }
-      ]
-    },
-    {
-      "email": "division12@goldcoast.qld.gov.au",
-      "id": "gold_coast_city_council/margaret_grummitt",
-      "name": "Pauline Young",
-      "sources": [
-        {
-          "url": "http://www.goldcoast.qld.gov.au/council/councillors-divisions-209.html"
-        }
-      ]
-    },
-    {
-      "email": "division10@goldcoast.qld.gov.au",
-      "id": "gold_coast_city_council/paul_taylor",
-      "image": "http://www.goldcoast.qld.gov.au/_images/Cr-Paul-Taylor-hs.jpg",
-      "name": "Paul Taylor",
+      "email": "gbrown@goldcoast.qld.gov.au",
+      "id": "gold_coast_city_council/dawn_crichlow",
+      "image": "http://www.goldcoast.qld.gov.au/_images/Cr-Dawn-Crichlow-hs.jpg",
+      "name": "Dawn Crichlow",
       "images": [
         {
-          "url": "http://www.goldcoast.qld.gov.au/_images/Cr-Paul-Taylor-hs.jpg"
+          "url": "http://www.goldcoast.qld.gov.au/_images/Cr-Dawn-Crichlow-hs.jpg"
         }
       ],
       "sources": [
@@ -1855,23 +1239,13 @@
       ]
     },
     {
-      "email": "division14@goldcoast.qld.gov.au",
-      "id": "gold_coast_city_council/tracey_gilmore",
-      "name": "Gail O'Neill",
-      "sources": [
-        {
-          "url": "http://www.goldcoast.qld.gov.au/council/councillors-divisions-209.html"
-        }
-      ]
-    },
-    {
-      "email": "division2@goldcoast.qld.gov.au",
-      "id": "gold_coast_city_council/william_owen-jones",
-      "image": "http://www.goldcoast.qld.gov.au/_images/Cr-William-Owen-Jones-hs.jpg",
-      "name": "William Owen-Jones",
+      "email": "mayor@goldcoast.qld.gov.au",
+      "id": "gold_coast_city_council/tom_tate",
+      "image": "http://www.goldcoast.qld.gov.au/_images/Mayor-Tom-Tate-hs.jpg",
+      "name": "Tom Tate",
       "images": [
         {
-          "url": "http://www.goldcoast.qld.gov.au/_images/Cr-William-Owen-Jones-hs.jpg"
+          "url": "http://www.goldcoast.qld.gov.au/_images/Mayor-Tom-Tate-hs.jpg"
         }
       ],
       "sources": [
@@ -1885,16 +1259,16 @@
       "name": "Graeme Scheu"
     },
     {
-      "id": "goondiwindi_regional_council/david_mcmahon",
-      "name": "David McMahon"
+      "id": "goondiwindi_regional_council/lachlan_brennan",
+      "name": "Lachlan Brennan"
+    },
+    {
+      "id": "goondiwindi_regional_council/david_turner",
+      "name": "David Turner"
     },
     {
       "id": "goondiwindi_regional_council/joan_white",
       "name": "Joan White"
-    },
-    {
-      "id": "goondiwindi_regional_council/lori_mackay",
-      "name": "Lori Mackay"
     },
     {
       "id": "goondiwindi_regional_council/rick_mcdougall",
@@ -1909,40 +1283,88 @@
       "name": "Rob MacKenzie"
     },
     {
-      "id": "gympie_regional_council/ray_currie",
-      "name": "Ray Currie"
+      "id": "gympie_regional_council/mick_curran",
+      "name": "Mick Curran"
     },
     {
       "id": "gympie_regional_council/bob_leitch",
       "name": "Bob Leitch"
     },
     {
-      "id": "gympie_regional_council/ian_petersen",
-      "name": "Ian Petersen"
+      "id": "gympie_regional_council/glen_hartwig",
+      "name": "Glen Hartwig"
     },
     {
-      "id": "gympie_regional_council/julie_walker",
-      "name": "Julie Walker"
+      "id": "gympie_regional_council/mal_gear",
+      "name": "Mal Gear"
     },
     {
-      "id": "gympie_regional_council/larry_friske",
-      "name": "Larry Friske"
+      "id": "gympie_regional_council/daryl_dodt",
+      "name": "Daryl Dodt"
+    },
+    {
+      "id": "gympie_regional_council/dan_stewart",
+      "name": "Dan Stewart"
+    },
+    {
+      "id": "gympie_regional_council/hilary_smerdon",
+      "name": "Hilary Smerdon"
+    },
+    {
+      "id": "gympie_regional_council/james_cochrane",
+      "name": "James Cochrane"
     },
     {
       "id": "gympie_regional_council/mark_mcdonald",
       "name": "Mark McDonald"
     },
     {
-      "id": "gympie_regional_council/mick_curran",
-      "name": "Mick Curran"
+      "id": "hinchinbrook_shire_council/ramon_jayo",
+      "name": "Ramon Jayo"
     },
     {
-      "id": "gympie_regional_council/rae_gate",
-      "name": "Rae Gate"
+      "id": "hinchinbrook_shire_council/maria_bosworth",
+      "name": "Maria Bosworth"
     },
     {
-      "id": "gympie_regional_council/wayne_sachs",
-      "name": "Wayne Sachs"
+      "id": "hinchinbrook_shire_council/mary_brown",
+      "name": "Mary Brown"
+    },
+    {
+      "id": "hinchinbrook_shire_council/andrew_lancini",
+      "name": "Andrew Lancini"
+    },
+    {
+      "id": "hinchinbrook_shire_council/kate_milton",
+      "name": "Kate Milton"
+    },
+    {
+      "id": "hinchinbrook_shire_council/marc_tack",
+      "name": "Marc Tack"
+    },
+    {
+      "id": "hinchinbrook_shire_council/wallis_(wally)_skinner",
+      "name": "Wallis (Wally) Skinner"
+    },
+    {
+      "id": "hope_vale_aboriginal_shire_council/barry_bowen",
+      "name": "Barry Bowen"
+    },
+    {
+      "id": "hope_vale_aboriginal_shire_council/selina_bowen",
+      "name": "Selina Bowen"
+    },
+    {
+      "id": "hope_vale_aboriginal_shire_council/bruce_gibson",
+      "name": "Bruce Gibson"
+    },
+    {
+      "id": "hope_vale_aboriginal_shire_council/greg_mclean",
+      "name": "Greg McLean"
+    },
+    {
+      "id": "hope_vale_aboriginal_shire_council/june_pearson",
+      "name": "June Pearson"
     },
     {
       "email": "ppisasale@ipswich.qld.gov.au",
@@ -1961,6 +1383,42 @@
       ]
     },
     {
+      "email": "ksilver@ipswich.qld.gov.au",
+      "id": "ipswich_city_council/kerry_silver",
+      "name": "Kerry Silver",
+      "sources": [
+        {
+          "url": "http://www.ipswich.qld.gov.au/about_council/mayor_and_councillors/division_3"
+        }
+      ]
+    },
+    {
+      "email": "kstoneman@ipswich.qld.gov.au",
+      "id": "ipswich_city_council/kylie_stoneman",
+      "image": "http://www.ipswich.qld.gov.au/__data/assets/image/0003/61338/kylie-stoneman.jpg",
+      "name": "Kylie Stoneman",
+      "images": [
+        {
+          "url": "http://www.ipswich.qld.gov.au/__data/assets/image/0003/61338/kylie-stoneman.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.ipswich.qld.gov.au/about_council/mayor_and_councillors/division_4"
+        }
+      ]
+    },
+    {
+      "email": "wwendt@ipswich.qld.gov.au",
+      "id": "ipswich_city_council/wayne_wendt",
+      "name": "Wayne Wendt",
+      "sources": [
+        {
+          "url": "http://www.ipswich.qld.gov.au/about_council/mayor_and_councillors/division_5"
+        }
+      ]
+    },
+    {
       "email": "aantoniolli@ipswich.qld.gov.au",
       "id": "ipswich_city_council/andrew_antoniolli",
       "image": "http://www.ipswich.qld.gov.au/__data/assets/image/0008/7559/crandrewantoniolli.jpg",
@@ -1973,16 +1431,6 @@
       "sources": [
         {
           "url": "http://www.ipswich.qld.gov.au/about_council/mayor_and_councillors/division_7"
-        }
-      ]
-    },
-    {
-      "email": "ksilver@ipswich.qld.gov.au",
-      "id": "ipswich_city_council/kerry_silver",
-      "name": "Kerry Silver",
-      "sources": [
-        {
-          "url": "http://www.ipswich.qld.gov.au/about_council/mayor_and_councillors/division_3"
         }
       ]
     },
@@ -2051,22 +1499,6 @@
       ]
     },
     {
-      "email": "kstoneman@ipswich.qld.gov.au",
-      "id": "ipswich_city_council/kylie_stoneman",
-      "image": "http://www.ipswich.qld.gov.au/__data/assets/image/0003/61338/kylie-stoneman.jpg",
-      "name": "Kylie Stoneman",
-      "images": [
-        {
-          "url": "http://www.ipswich.qld.gov.au/__data/assets/image/0003/61338/kylie-stoneman.jpg"
-        }
-      ],
-      "sources": [
-        {
-          "url": "http://www.ipswich.qld.gov.au/about_council/mayor_and_councillors/division_4"
-        }
-      ]
-    },
-    {
       "email": "ptully@ipswich.qld.gov.au",
       "id": "ipswich_city_council/paul_tully",
       "image": "http://www.ipswich.qld.gov.au/__data/assets/image/0008/9692/cr_paul_tully.jpg",
@@ -2099,22 +1531,124 @@
       ]
     },
     {
-      "email": "wwendt@ipswich.qld.gov.au",
-      "id": "ipswich_city_council/wayne_wendt",
-      "name": "Wayne Wendt",
-      "sources": [
-        {
-          "url": "http://www.ipswich.qld.gov.au/about_council/mayor_and_councillors/division_5"
-        }
-      ]
+      "id": "isaac_regional_council/anne_baker",
+      "name": "Anne Baker"
+    },
+    {
+      "id": "isaac_regional_council/lynette_(lyn)_jones",
+      "name": "Lynette (Lyn) Jones"
+    },
+    {
+      "id": "isaac_regional_council/dale_appleton",
+      "name": "Dale Appleton"
+    },
+    {
+      "id": "isaac_regional_council/delville_(nick)_wheeler",
+      "name": "Delville (Nick) Wheeler"
+    },
+    {
+      "id": "isaac_regional_council/geoffrey_bethel",
+      "name": "Geoffrey Bethel"
+    },
+    {
+      "id": "isaac_regional_council/gina_lacey",
+      "name": "Gina Lacey"
+    },
+    {
+      "id": "isaac_regional_council/jane_pickels",
+      "name": "Jane Pickels"
+    },
+    {
+      "id": "isaac_regional_council/kelly_vea_vea",
+      "name": "Kelly Vea Vea"
+    },
+    {
+      "id": "isaac_regional_council/peter_freeleagus",
+      "name": "Peter Freeleagus"
+    },
+    {
+      "id": "kowanyama_aboriginal_shire_council/michael_yam",
+      "name": "Michael Yam"
+    },
+    {
+      "id": "kowanyama_aboriginal_shire_council/territa_dick",
+      "name": "Territa Dick"
+    },
+    {
+      "id": "kowanyama_aboriginal_shire_council/john_fry",
+      "name": "John Fry"
+    },
+    {
+      "id": "kowanyama_aboriginal_shire_council/colin_lawrence",
+      "name": "Colin Lawrence"
+    },
+    {
+      "id": "kowanyama_aboriginal_shire_council/wendy_wust",
+      "name": "Wendy Wust"
+    },
+    {
+      "id": "livingstone_shire_council/bill_ludwig",
+      "name": "Bill Ludwig"
+    },
+    {
+      "id": "livingstone_shire_council/adam_belot",
+      "name": "Adam Belot"
+    },
+    {
+      "id": "livingstone_shire_council/glenda_mather",
+      "name": "Glenda Mather"
+    },
+    {
+      "id": "livingstone_shire_council/graham_scott",
+      "name": "Graham Scott"
+    },
+    {
+      "id": "livingstone_shire_council/jan_kelly",
+      "name": "Jan Kelly"
+    },
+    {
+      "id": "livingstone_shire_council/nigel_hutton",
+      "name": "Nigel Hutton"
+    },
+    {
+      "id": "livingstone_shire_council/tom_wyatt",
+      "name": "Tom Wyatt"
+    },
+    {
+      "id": "lockhart_river_aboriginal_shire_council/wayne_butcher",
+      "name": "Wayne Butcher"
+    },
+    {
+      "id": "lockhart_river_aboriginal_shire_council/marshall_symonds",
+      "name": "Marshall Symonds"
+    },
+    {
+      "id": "lockhart_river_aboriginal_shire_council/dorothy_hobson",
+      "name": "Dorothy Hobson"
+    },
+    {
+      "id": "lockhart_river_aboriginal_shire_council/norman_bally",
+      "name": "Norman Bally"
+    },
+    {
+      "id": "lockhart_river_aboriginal_shire_council/paul_piva",
+      "name": "Paul Piva"
     },
     {
       "id": "lockyer_valley_regional_council/steve_jones",
       "name": "Steve Jones"
     },
     {
-      "id": "lockyer_valley_regional_council/derek_pingel",
-      "name": "Derek Pingel"
+      "id": "lockyer_valley_regional_council/michael_hagan",
+      "name": "Michael Hagan"
+    },
+    {
+      "id": "lockyer_valley_regional_council/jason_cook",
+      "name": "Jason Cook"
+    },
+    {
+      "id": "lockyer_valley_regional_council/chris_wilson",
+      "name": "Chris Wilson"
     },
     {
       "id": "lockyer_valley_regional_council/janice_holstein",
@@ -2129,17 +1663,39 @@
       "name": "Kathy McLean"
     },
     {
-      "id": "lockyer_valley_regional_council/peter_friend",
-      "name": "Peter Friend"
-    },
-    {
-      "id": "lockyer_valley_regional_council/tanya_milligan",
-      "name": "Tanya Milligan"
+      "email": "mayor@logan.qld.gov.au",
+      "id": "logan_city_council/luke_smith",
+      "name": "Luke Smith",
+      "sources": [
+        {
+          "url": "http://www.logan.qld.gov.au/about-council/mayor-and-councillors/councillors"
+        }
+      ]
     },
     {
       "email": "lauriekoranski@logan.qld.gov.au",
       "id": "logan_city_council/laurie_koranski",
       "name": "Laurie Koranski",
+      "sources": [
+        {
+          "url": "http://www.logan.qld.gov.au/about-council/mayor-and-councillors/councillors"
+        }
+      ]
+    },
+    {
+      "email": "jonraven@logan.qld.gov.au",
+      "id": "logan_city_council/jon_raven",
+      "name": "Jon Raven",
+      "sources": [
+        {
+          "url": "http://www.logan.qld.gov.au/about-council/mayor-and-councillors/councillors"
+        }
+      ]
+    },
+    {
+      "email": "staceymcintosh@logan.qld.gov.au",
+      "id": "logan_city_council/stacey_mcintosh",
+      "name": "Stacey McIntosh",
       "sources": [
         {
           "url": "http://www.logan.qld.gov.au/about-council/mayor-and-councillors/councillors"
@@ -2160,26 +1716,6 @@
       "email": "darrenpower@logan.qld.gov.au",
       "id": "logan_city_council/darren_power",
       "name": "Darren Power",
-      "sources": [
-        {
-          "url": "http://www.logan.qld.gov.au/about-council/mayor-and-councillors/councillors"
-        }
-      ]
-    },
-    {
-      "email": "jonraven@logan.qld.gov.au",
-      "id": "logan_city_council/jon_raven",
-      "name": "Jon Raven",
-      "sources": [
-        {
-          "url": "http://www.logan.qld.gov.au/about-council/mayor-and-councillors/councillors"
-        }
-      ]
-    },
-    {
-      "email": "staceymcintosh@logan.qld.gov.au",
-      "id": "logan_city_council/graham_able",
-      "name": "Stacey McIntosh",
       "sources": [
         {
           "url": "http://www.logan.qld.gov.au/about-council/mayor-and-councillors/councillors"
@@ -2210,16 +1746,6 @@
       "email": "lisabradley@logan.qld.gov.au",
       "id": "logan_city_council/lisa_bradley",
       "name": "Lisa Bradley",
-      "sources": [
-        {
-          "url": "http://www.logan.qld.gov.au/about-council/mayor-and-councillors/councillors"
-        }
-      ]
-    },
-    {
-      "email": "mayor@logan.qld.gov.au",
-      "id": "logan_city_council/luke_smith",
-      "name": "Luke Smith",
       "sources": [
         {
           "url": "http://www.logan.qld.gov.au/about-council/mayor-and-councillors/councillors"
@@ -2267,8 +1793,193 @@
       ]
     },
     {
-      "id": "maranoa_regional_council/robert_loughnan",
-      "name": "Robert Loughnan"
+      "id": "longreach_regional_council/joe_owens",
+      "name": "Joe Owens"
+    },
+    {
+      "id": "longreach_regional_council/leonie_nunn",
+      "name": "Leonie Nunn"
+    },
+    {
+      "id": "longreach_regional_council/trevor_harris",
+      "name": "Trevor Harris"
+    },
+    {
+      "id": "longreach_regional_council/tony_martin",
+      "name": "Tony Martin"
+    },
+    {
+      "id": "longreach_regional_council/anthony_rayner",
+      "name": "Anthony Rayner"
+    },
+    {
+      "id": "longreach_regional_council/anthony_emslie",
+      "name": "Anthony Emslie"
+    },
+    {
+      "id": "longreach_regional_council/trevor_smith",
+      "name": "Trevor Smith"
+    },
+    {
+      "email": "greg.williamson@mackay.qld.gov.au",
+      "id": "mackay_regional_council/greg_williamson",
+      "image": "http://www.mackay.qld.gov.au/__data/assets/image/0006/197718/Greg-Williamson.png",
+      "name": "Greg Williamson",
+      "images": [
+        {
+          "url": "http://www.mackay.qld.gov.au/__data/assets/image/0006/197718/Greg-Williamson.png"
+        }
+      ]
+    },
+    {
+      "email": "amanda.camm@mackay.qld.gov.au",
+      "id": "mackay_regional_council/amanda_camm",
+      "image": "http://www.mackay.qld.gov.au/__data/assets/image/0003/197715/Amanda-Camm.png",
+      "name": "Amanda Camm",
+      "images": [
+        {
+          "url": "http://www.mackay.qld.gov.au/__data/assets/image/0003/197715/Amanda-Camm.png"
+        }
+      ]
+    },
+    {
+      "email": "kevin.casey@mackay.qld.gov.au",
+      "id": "mackay_regional_council/kevin_casey",
+      "image": "http://www.mackay.qld.gov.au/__data/assets/image/0009/197721/Kevin-Casey.png",
+      "name": "Kevin Casey",
+      "images": [
+        {
+          "url": "http://www.mackay.qld.gov.au/__data/assets/image/0009/197721/Kevin-Casey.png"
+        }
+      ]
+    },
+    {
+      "email": "cr.justin.englert@mackay.qld.gov.au",
+      "id": "mackay_regional_council/justin_englert",
+      "image": "http://www.mackay.qld.gov.au/__data/assets/image/0007/197719/Justin-Englert.png",
+      "name": "Justin Englert",
+      "images": [
+        {
+          "url": "http://www.mackay.qld.gov.au/__data/assets/image/0007/197719/Justin-Englert.png"
+        }
+      ]
+    },
+    {
+      "email": "cr.fran.fordham@mackay.qld.gov.au",
+      "id": "mackay_regional_council/fran_fordham",
+      "image": "http://www.mackay.qld.gov.au/__data/assets/image/0005/197717/Fran-Fordham.png",
+      "name": "Fran Fordham",
+      "images": [
+        {
+          "url": "http://www.mackay.qld.gov.au/__data/assets/image/0005/197717/Fran-Fordham.png"
+        }
+      ]
+    },
+    {
+      "email": "ross.gee@mackay.qld.gov.au",
+      "id": "mackay_regional_council/ross_gee",
+      "image": "http://www.mackay.qld.gov.au/__data/assets/image/0003/197724/Ross-Gee.png",
+      "name": "Ross Gee",
+      "images": [
+        {
+          "url": "http://www.mackay.qld.gov.au/__data/assets/image/0003/197724/Ross-Gee.png"
+        }
+      ]
+    },
+    {
+      "email": "karen.may@mackay.qld.gov.au",
+      "id": "mackay_regional_council/karen_may",
+      "image": "http://www.mackay.qld.gov.au/__data/assets/image/0008/197720/Karen-May.png",
+      "name": "Karen May",
+      "images": [
+        {
+          "url": "http://www.mackay.qld.gov.au/__data/assets/image/0008/197720/Karen-May.png"
+        }
+      ]
+    },
+    {
+      "email": "ayril.paton@mackay.qld.gov.au",
+      "id": "mackay_regional_council/ayril_paton",
+      "image": "http://www.mackay.qld.gov.au/__data/assets/image/0004/197716/Ayril-Paton.png",
+      "name": "Ayril Paton",
+      "images": [
+        {
+          "url": "http://www.mackay.qld.gov.au/__data/assets/image/0004/197716/Ayril-Paton.png"
+        }
+      ]
+    },
+    {
+      "email": "martin.bella@mackay.qld.gov.au",
+      "id": "mackay_regional_council/martin_bella",
+      "image": "http://www.mackay.qld.gov.au/__data/assets/image/0011/197723/Martin-Bella.png",
+      "name": "Martin Bella",
+      "images": [
+        {
+          "url": "http://www.mackay.qld.gov.au/__data/assets/image/0011/197723/Martin-Bella.png"
+        }
+      ]
+    },
+    {
+      "email": "laurence.bonaventura@mackay.qld.gov.au",
+      "id": "mackay_regional_council/laurence_bonaventura",
+      "image": "http://www.mackay.qld.gov.au/__data/assets/image/0010/197722/Laurence-Bonaventura.png",
+      "name": "Laurence Bonaventura",
+      "images": [
+        {
+          "url": "http://www.mackay.qld.gov.au/__data/assets/image/0010/197722/Laurence-Bonaventura.png"
+        }
+      ]
+    },
+    {
+      "email": "ross.walker@mackay.qld.gov.au",
+      "id": "mackay_regional_council/ross_walker",
+      "image": "http://www.mackay.qld.gov.au/__data/assets/image/0004/197725/Ross-Walker.png",
+      "name": "Ross Walker",
+      "images": [
+        {
+          "url": "http://www.mackay.qld.gov.au/__data/assets/image/0004/197725/Ross-Walker.png"
+        }
+      ]
+    },
+    {
+      "id": "mapoon_aboriginal_shire_council/aileen_addo",
+      "name": "Aileen Addo"
+    },
+    {
+      "id": "mapoon_aboriginal_shire_council/margaret_mara",
+      "name": "Margaret Mara"
+    },
+    {
+      "id": "mapoon_aboriginal_shire_council/brendan_brown",
+      "name": "Brendan Brown"
+    },
+    {
+      "id": "mapoon_aboriginal_shire_council/peter_guivarra",
+      "name": "Peter Guivarra"
+    },
+    {
+      "id": "mapoon_aboriginal_shire_council/pauline_smith",
+      "name": "Pauline Smith"
+    },
+    {
+      "id": "maranoa_regional_council/tyson_golder",
+      "name": "Tyson Golder"
+    },
+    {
+      "id": "maranoa_regional_council/robyn_bryant",
+      "name": "Robyn Bryant"
+    },
+    {
+      "id": "maranoa_regional_council/geoff_mcmullen",
+      "name": "Geoff McMullen"
+    },
+    {
+      "id": "maranoa_regional_council/janelle_stanford",
+      "name": "Janelle Stanford"
+    },
+    {
+      "id": "maranoa_regional_council/n_(puddy)_chandler",
+      "name": "N (Puddy) Chandler"
     },
     {
       "id": "maranoa_regional_council/cameron_o'neil",
@@ -2283,24 +1994,56 @@
       "name": "Jan Chambers"
     },
     {
-      "id": "maranoa_regional_council/joy_denton",
-      "name": "Joy Denton"
-    },
-    {
       "id": "maranoa_regional_council/peter_flynn",
       "name": "Peter Flynn"
     },
     {
-      "id": "maranoa_regional_council/ree_price",
-      "name": "Ree Price"
+      "id": "mareeba_shire_council/tom_gilmore",
+      "name": "Tom Gilmore"
     },
     {
-      "id": "maranoa_regional_council/scott_wason",
-      "name": "Scott Wason"
+      "id": "mareeba_shire_council/kevin_davies",
+      "name": "Kevin Davies"
     },
     {
-      "id": "maranoa_regional_council/wendy_newman",
-      "name": "Wendy Newman"
+      "id": "mareeba_shire_council/angela_toppin",
+      "name": "Angela Toppin"
+    },
+    {
+      "id": "mareeba_shire_council/lenore_wyatt",
+      "name": "Lenore Wyatt"
+    },
+    {
+      "id": "mareeba_shire_council/alan_pedersen",
+      "name": "Alan Pedersen"
+    },
+    {
+      "id": "mareeba_shire_council/edward_(nipper)_brown",
+      "name": "Edward (Nipper) Brown"
+    },
+    {
+      "id": "mareeba_shire_council/mary_graham",
+      "name": "Mary Graham"
+    },
+    {
+      "id": "mckinlay_shire_council/belinda_murphy",
+      "name": "Belinda Murphy"
+    },
+    {
+      "id": "mckinlay_shire_council/shauna_royes",
+      "name": "Shauna Royes"
+    },
+    {
+      "id": "mckinlay_shire_council/janene_fegan",
+      "name": "Janene Fegan"
+    },
+    {
+      "id": "mckinlay_shire_council/neil_walker",
+      "name": "Neil Walker"
+    },
+    {
+      "id": "mckinlay_shire_council/philip_curr",
+      "name": "Philip Curr"
     },
     {
       "email": "mayor@moretonbay.qld.gov.au",
@@ -2335,22 +2078,6 @@
       ]
     },
     {
-      "email": "Peter.Flannery@moretonbay.qld.gov.au",
-      "id": "moreton_bay_regional_council/peter_flannery",
-      "image": "https://www.moretonbay.qld.gov.au/uploadedImages/common/councillors/peter-flannery.jpg",
-      "name": "Peter Flannery",
-      "images": [
-        {
-          "url": "https://www.moretonbay.qld.gov.au/uploadedImages/common/councillors/peter-flannery.jpg"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://www.moretonbay.qld.gov.au/general.aspx?id=103921"
-        }
-      ]
-    },
-    {
       "email": "Adam.Hain@moretonbay.qld.gov.au",
       "id": "moreton_bay_regional_council/adam_hain",
       "image": "https://www.moretonbay.qld.gov.au/uploadedImages/common/councillors/adam-hain.jpg",
@@ -2367,54 +2094,6 @@
       ]
     },
     {
-      "email": "Julie.Greer@moretonbay.qld.gov.au",
-      "id": "moreton_bay_regional_council/julie_greer",
-      "image": "https://www.moretonbay.qld.gov.au/uploadedImages/common/councillors/julie-greer.jpg",
-      "name": "Julie Greer",
-      "images": [
-        {
-          "url": "https://www.moretonbay.qld.gov.au/uploadedImages/common/councillors/julie-greer.jpg"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://www.moretonbay.qld.gov.au/general.aspx?id=18311"
-        }
-      ]
-    },
-    {
-      "email": "Division5@moretonbay.qld.gov.au",
-      "id": "moreton_bay_regional_council/james_houghton",
-      "image": "https://www.moretonbay.qld.gov.au/uploadedImages/common/councillors/james-houghton.jpg",
-      "name": "James Houghton",
-      "images": [
-        {
-          "url": "https://www.moretonbay.qld.gov.au/uploadedImages/common/councillors/james-houghton.jpg"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://www.moretonbay.qld.gov.au/general.aspx?id=18315"
-        }
-      ]
-    },
-    {
-      "email": "Koliana.Winchester@moretonbay.qld.gov.au",
-      "id": "moreton_bay_regional_council/koliana_winchester",
-      "image": "https://www.moretonbay.qld.gov.au/uploadedImages/common/councillors/koliana-winchester.jpg",
-      "name": "Koliana Winchester",
-      "images": [
-        {
-          "url": "https://www.moretonbay.qld.gov.au/uploadedImages/common/councillors/koliana-winchester.jpg"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://www.moretonbay.qld.gov.au/general.aspx?id=103922"
-        }
-      ]
-    },
-    {
       "email": "Denise.Sims@moretonbay.qld.gov.au",
       "id": "moreton_bay_regional_council/denise_sims",
       "image": "https://www.moretonbay.qld.gov.au/uploadedImages/common/councillors/denise-sims.jpg",
@@ -2427,38 +2106,6 @@
       "sources": [
         {
           "url": "https://www.moretonbay.qld.gov.au/general.aspx?id=18323"
-        }
-      ]
-    },
-    {
-      "email": "Mick.Gillam@moretonbay.qld.gov.au",
-      "id": "moreton_bay_regional_council/mick_gillam",
-      "image": "https://www.moretonbay.qld.gov.au/uploadedImages/common/councillors/mick-gillam.jpg",
-      "name": "Mick Gillam",
-      "images": [
-        {
-          "url": "https://www.moretonbay.qld.gov.au/uploadedImages/common/councillors/mick-gillam.jpg"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://www.moretonbay.qld.gov.au/general.aspx?id=18325"
-        }
-      ]
-    },
-    {
-      "email": "Mike.Charlton@moretonbay.qld.gov.au",
-      "id": "moreton_bay_regional_council/mike_charlton",
-      "image": "https://www.moretonbay.qld.gov.au/uploadedImages/common/councillors/mike-charlton.jpg",
-      "name": "Mike Charlton",
-      "images": [
-        {
-          "url": "https://www.moretonbay.qld.gov.au/uploadedImages/common/councillors/mike-charlton.jpg"
-        }
-      ],
-      "sources": [
-        {
-          "url": "https://www.moretonbay.qld.gov.au/general.aspx?id=18327"
         }
       ]
     },
@@ -2511,16 +2158,160 @@
       ]
     },
     {
-      "id": "murweh_shire_council/denis_cook",
-      "name": "Denis Cook"
+      "email": "Division5@moretonbay.qld.gov.au",
+      "id": "moreton_bay_regional_council/james_houghton",
+      "image": "https://www.moretonbay.qld.gov.au/uploadedImages/common/councillors/james-houghton.jpg",
+      "name": "James Houghton",
+      "images": [
+        {
+          "url": "https://www.moretonbay.qld.gov.au/uploadedImages/common/councillors/james-houghton.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "https://www.moretonbay.qld.gov.au/general.aspx?id=18315"
+        }
+      ]
+    },
+    {
+      "email": "Julie.Greer@moretonbay.qld.gov.au",
+      "id": "moreton_bay_regional_council/julie_greer",
+      "image": "https://www.moretonbay.qld.gov.au/uploadedImages/common/councillors/julie-greer.jpg",
+      "name": "Julie Greer",
+      "images": [
+        {
+          "url": "https://www.moretonbay.qld.gov.au/uploadedImages/common/councillors/julie-greer.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "https://www.moretonbay.qld.gov.au/general.aspx?id=18311"
+        }
+      ]
+    },
+    {
+      "email": "Koliana.Winchester@moretonbay.qld.gov.au",
+      "id": "moreton_bay_regional_council/koliana_winchester",
+      "image": "https://www.moretonbay.qld.gov.au/uploadedImages/common/councillors/koliana-winchester.jpg",
+      "name": "Koliana Winchester",
+      "images": [
+        {
+          "url": "https://www.moretonbay.qld.gov.au/uploadedImages/common/councillors/koliana-winchester.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "https://www.moretonbay.qld.gov.au/general.aspx?id=103922"
+        }
+      ]
+    },
+    {
+      "email": "Mick.Gillam@moretonbay.qld.gov.au",
+      "id": "moreton_bay_regional_council/mick_gillam",
+      "image": "https://www.moretonbay.qld.gov.au/uploadedImages/common/councillors/mick-gillam.jpg",
+      "name": "Mick Gillam",
+      "images": [
+        {
+          "url": "https://www.moretonbay.qld.gov.au/uploadedImages/common/councillors/mick-gillam.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "https://www.moretonbay.qld.gov.au/general.aspx?id=18325"
+        }
+      ]
+    },
+    {
+      "email": "Mike.Charlton@moretonbay.qld.gov.au",
+      "id": "moreton_bay_regional_council/mike_charlton",
+      "image": "https://www.moretonbay.qld.gov.au/uploadedImages/common/councillors/mike-charlton.jpg",
+      "name": "Mike Charlton",
+      "images": [
+        {
+          "url": "https://www.moretonbay.qld.gov.au/uploadedImages/common/councillors/mike-charlton.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "https://www.moretonbay.qld.gov.au/general.aspx?id=18327"
+        }
+      ]
+    },
+    {
+      "email": "Peter.Flannery@moretonbay.qld.gov.au",
+      "id": "moreton_bay_regional_council/peter_flannery",
+      "image": "https://www.moretonbay.qld.gov.au/uploadedImages/common/councillors/peter-flannery.jpg",
+      "name": "Peter Flannery",
+      "images": [
+        {
+          "url": "https://www.moretonbay.qld.gov.au/uploadedImages/common/councillors/peter-flannery.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "https://www.moretonbay.qld.gov.au/general.aspx?id=103921"
+        }
+      ]
+    },
+    {
+      "id": "mornington_shire_council/bradley_wilson",
+      "name": "Bradley Wilson"
+    },
+    {
+      "id": "mornington_shire_council/sarah_isaacs",
+      "name": "Sarah Isaacs"
+    },
+    {
+      "id": "mornington_shire_council/jane_ah_kit",
+      "name": "Jane Ah Kit"
+    },
+    {
+      "id": "mornington_shire_council/clair_farrell",
+      "name": "Clair Farrell"
+    },
+    {
+      "id": "mornington_shire_council/bob_thompson",
+      "name": "Bob Thompson"
+    },
+    {
+      "id": "mount_isa_city_council/joyce_mcculloch",
+      "name": "Joyce McCulloch"
+    },
+    {
+      "id": "mount_isa_city_council/peta_macrae",
+      "name": "Peta MacRae"
+    },
+    {
+      "id": "mount_isa_city_council/phil_barwick",
+      "name": "Phil Barwick"
+    },
+    {
+      "id": "mount_isa_city_council/paul_stretton",
+      "name": "Paul Stretton"
+    },
+    {
+      "id": "mount_isa_city_council/mick_tully",
+      "name": "Mick Tully"
+    },
+    {
+      "id": "mount_isa_city_council/george_fortune",
+      "name": "George Fortune"
+    },
+    {
+      "id": "mount_isa_city_council/jean_ferris",
+      "name": "Jean Ferris"
     },
     {
       "id": "murweh_shire_council/anne_maree_liston",
       "name": "Anne Maree Liston"
     },
     {
-      "id": "murweh_shire_council/cecil_russell",
-      "name": "Cecil Russell"
+      "id": "murweh_shire_council/shaun_(zoro)_radnedge",
+      "name": "Shaun (Zoro) Radnedge"
+    },
+    {
+      "id": "murweh_shire_council/lyn_capewell",
+      "name": "Lyn Capewell"
     },
     {
       "id": "murweh_shire_council/peter_alexander",
@@ -2531,40 +2322,140 @@
       "name": "Robert Eckel"
     },
     {
+      "id": "napranum_aboriginal_shire_council/rex_burke",
+      "name": "Rex Burke"
+    },
+    {
+      "id": "napranum_aboriginal_shire_council/ethel_bosuen",
+      "name": "Ethel Bosuen"
+    },
+    {
+      "id": "napranum_aboriginal_shire_council/sonia_schuh",
+      "name": "Sonia Schuh"
+    },
+    {
+      "id": "napranum_aboriginal_shire_council/fiona_wirrer-george",
+      "name": "Fiona Wirrer-George"
+    },
+    {
+      "id": "napranum_aboriginal_shire_council/rhonda_charger",
+      "name": "Rhonda Charger"
+    },
+    {
+      "id": "noosa_shire_council/tony_wellington",
+      "name": "Tony Wellington"
+    },
+    {
+      "id": "noosa_shire_council/jess_glasgow",
+      "name": "Jess Glasgow"
+    },
+    {
+      "id": "noosa_shire_council/ingrid_jackson",
+      "name": "Ingrid Jackson"
+    },
+    {
+      "id": "noosa_shire_council/brian_stockwell",
+      "name": "Brian Stockwell"
+    },
+    {
+      "id": "noosa_shire_council/bob_abbott",
+      "name": "Bob Abbott"
+    },
+    {
+      "id": "noosa_shire_council/frank_pardon",
+      "name": "Frank Pardon"
+    },
+    {
+      "id": "noosa_shire_council/frank_wilkie",
+      "name": "Frank Wilkie"
+    },
+    {
+      "id": "noosa_shire_council/joe_jurisevic",
+      "name": "Joe Jurisevic"
+    },
+    {
+      "id": "noosa_shire_council/sandy_bolton",
+      "name": "Sandy Bolton"
+    },
+    {
       "id": "north_burnett_regional_council/don_waugh",
       "name": "Don Waugh"
+    },
+    {
+      "id": "north_burnett_regional_council/peter_webster",
+      "name": "Peter Webster"
+    },
+    {
+      "id": "north_burnett_regional_council/john_zahl",
+      "name": "John Zahl"
+    },
+    {
+      "id": "north_burnett_regional_council/robert_radel",
+      "name": "Robert Radel"
     },
     {
       "id": "north_burnett_regional_council/faye_whelan",
       "name": "Faye Whelan"
     },
     {
-      "id": "north_burnett_regional_council/joanne_dowling",
-      "name": "Joanne Dowling"
-    },
-    {
       "id": "north_burnett_regional_council/john_bowen",
       "name": "John Bowen"
-    },
-    {
-      "id": "north_burnett_regional_council/kevin_(lofty)_wendt",
-      "name": "Kevin (Lofty) Wendt"
-    },
-    {
-      "id": "north_burnett_regional_council/paul_francis",
-      "name": "Paul Francis"
     },
     {
       "id": "north_burnett_regional_council/paul_lobegeier",
       "name": "Paul Lobegeier"
     },
     {
+      "id": "northern_peninsula_area_regional_council/edward_newman",
+      "name": "Edward Newman"
+    },
+    {
+      "id": "northern_peninsula_area_regional_council/gina_nona",
+      "name": "Gina Nona"
+    },
+    {
+      "id": "northern_peninsula_area_regional_council/peter_lui",
+      "name": "Peter Lui"
+    },
+    {
+      "id": "northern_peninsula_area_regional_council/cassandra_adidi",
+      "name": "Cassandra Adidi"
+    },
+    {
+      "id": "northern_peninsula_area_regional_council/michael_bond",
+      "name": "Michael Bond"
+    },
+    {
+      "id": "northern_peninsula_area_regional_council/joseph_elu",
+      "name": "Joseph Elu"
+    },
+    {
+      "id": "palm_island_aboriginal_shire_council/alfred_lacey",
+      "name": "Alfred Lacey"
+    },
+    {
+      "id": "palm_island_aboriginal_shire_council/robert_castors",
+      "name": "Robert Castors"
+    },
+    {
+      "id": "palm_island_aboriginal_shire_council/deniece_geia",
+      "name": "Deniece Geia"
+    },
+    {
+      "id": "palm_island_aboriginal_shire_council/edward_walsh",
+      "name": "Edward Walsh"
+    },
+    {
+      "id": "palm_island_aboriginal_shire_council/roy_prior",
+      "name": "Roy Prior"
+    },
+    {
       "id": "paroo_shire_council/lindsay_godfrey",
       "name": "Lindsay Godfrey"
     },
     {
-      "id": "paroo_shire_council/david_land",
-      "name": "David Land"
+      "id": "paroo_shire_council/joann_woodcroft",
+      "name": "Joann Woodcroft"
     },
     {
       "id": "paroo_shire_council/don_dunsdon",
@@ -2575,76 +2466,383 @@
       "name": "Neil Hatchman"
     },
     {
-      "id": "paroo_shire_council/richard_brain",
-      "name": "Richard Brain"
+      "id": "paroo_shire_council/rick_brain",
+      "name": "Rick Brain"
+    },
+    {
+      "id": "pormpuraaw_aboriginal_shire_council/"
+    },
+    {
+      "id": "pormpuraaw_aboriginal_shire_council/keith_barney",
+      "name": "Keith Barney"
+    },
+    {
+      "id": "pormpuraaw_aboriginal_shire_council/george_simeon_conrad",
+      "name": "George Simeon Conrad"
+    },
+    {
+      "id": "pormpuraaw_aboriginal_shire_council/bert_edwards",
+      "name": "Bert Edwards"
+    },
+    {
+      "id": "pormpuraaw_aboriginal_shire_council/tim_koo-aga",
+      "name": "Tim Koo-Aga"
     },
     {
       "id": "quilpie_shire_council/stuart_mackenzie",
       "name": "Stuart MacKenzie"
     },
     {
+      "id": "quilpie_shire_council/robert_hall",
+      "name": "Robert Hall"
+    },
+    {
+      "id": "quilpie_shire_council/roger_volz",
+      "name": "Roger Volz"
+    },
+    {
+      "id": "quilpie_shire_council/bruce_paulsen",
+      "name": "Bruce Paulsen"
+    },
+    {
       "id": "quilpie_shire_council/jenny_hewson",
       "name": "Jenny Hewson"
     },
     {
-      "id": "quilpie_shire_council/milan_milosevic",
-      "name": "Milan Milosevic"
-    },
-    {
-      "id": "quilpie_shire_council/stewart_sargent",
-      "name": "Stewart Sargent"
-    },
-    {
-      "id": "quilpie_shire_council/tony_lilburne",
-      "name": "Tony Lilburne"
-    },
-    {
+      "email": "mayor@redland.qld.gov.au",
       "id": "redland_city_council/karen_williams",
-      "name": "Karen Williams"
+      "image": "http://www.redland.qld.gov.au/SiteCollectionImages/Council/Councillors%20Mayor/Mayor_WEB.jpg",
+      "name": "Karen Williams",
+      "images": [
+        {
+          "url": "http://www.redland.qld.gov.au/SiteCollectionImages/Council/Councillors%20Mayor/Mayor_WEB.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.redland.qld.gov.au/AboutCouncil/MayorCouncillors/Pages/Mayor.aspx"
+        }
+      ]
     },
     {
-      "id": "redland_city_council/alan_beard",
-      "name": "Alan Beard"
+      "email": "Peter.Mitchell@redland.qld.gov.au",
+      "id": "redland_city_council/peter_mitchell",
+      "image": "http://www.redland.qld.gov.au/SiteCollectionImages/Council/Councillors%20Mayor/petermitchell.jpg",
+      "name": "Peter Mitchell",
+      "images": [
+        {
+          "url": "http://www.redland.qld.gov.au/SiteCollectionImages/Council/Councillors%20Mayor/petermitchell.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.redland.qld.gov.au/AboutCouncil/MayorCouncillors/Pages/Division2.aspx"
+        }
+      ]
     },
     {
-      "id": "redland_city_council/craig_ogilvie",
-      "name": "Craig Ogilvie"
+      "email": "Paul.Golle@redland.qld.gov.au",
+      "id": "redland_city_council/paul_golle",
+      "image": "http://www.redland.qld.gov.au/SiteCollectionImages/Council/Councillors%20Mayor/paulgolle.jpg",
+      "name": "Paul Golle",
+      "images": [
+        {
+          "url": "http://www.redland.qld.gov.au/SiteCollectionImages/Council/Councillors%20Mayor/paulgolle.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.redland.qld.gov.au/AboutCouncil/MayorCouncillors/Pages/Division3.aspx"
+        }
+      ]
     },
     {
+      "email": "Tracey.huges@redland.qld.gov.au",
+      "id": "redland_city_council/tracey_huges",
+      "image": "http://www.redland.qld.gov.au/SiteCollectionImages/Council/Councillors%20Mayor/cr-huges-140-180.jpg",
+      "name": "Tracey Huges",
+      "images": [
+        {
+          "url": "http://www.redland.qld.gov.au/SiteCollectionImages/Council/Councillors%20Mayor/cr-huges-140-180.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.redland.qld.gov.au/AboutCouncil/MayorCouncillors/Pages/Division8.aspx"
+        }
+      ]
+    },
+    {
+      "email": "julie.talty@redland.qld.gov.au",
       "id": "redland_city_council/julie_talty",
-      "name": "Julie Talty"
+      "image": "http://www.redland.qld.gov.au/SiteCollectionImages/Council/Councillors%20Mayor/Councillor_Talty_WEB.jpg",
+      "name": "Julie Talty",
+      "images": [
+        {
+          "url": "http://www.redland.qld.gov.au/SiteCollectionImages/Council/Councillors%20Mayor/Councillor_Talty_WEB.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.redland.qld.gov.au/AboutCouncil/MayorCouncillors/Pages/Division6.aspx"
+        }
+      ]
     },
     {
-      "id": "redland_city_council/kim-maree_hardman",
-      "name": "Kim-Maree Hardman"
-    },
-    {
+      "email": "lance.hewlett@redland.qld.gov.au",
       "id": "redland_city_council/lance_hewlett",
-      "name": "Lance Hewlett"
+      "image": "http://www.redland.qld.gov.au/SiteCollectionImages/Council/Councillors%20Mayor/Councillor_Hewlett_WEB.jpg",
+      "name": "Lance Hewlett",
+      "images": [
+        {
+          "url": "http://www.redland.qld.gov.au/SiteCollectionImages/Council/Councillors%20Mayor/Councillor_Hewlett_WEB.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.redland.qld.gov.au/AboutCouncil/MayorCouncillors/Pages/Division4.aspx"
+        }
+      ]
     },
     {
+      "email": "mark.edwards@redland.qld.gov.au",
       "id": "redland_city_council/mark_edwards",
-      "name": "Mark Edwards"
+      "image": "http://www.redland.qld.gov.au/SiteCollectionImages/Council/Councillors%20Mayor/Councillor_Edwards_WEB.jpg",
+      "name": "Mark Edwards",
+      "images": [
+        {
+          "url": "http://www.redland.qld.gov.au/SiteCollectionImages/Council/Councillors%20Mayor/Councillor_Edwards_WEB.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.redland.qld.gov.au/AboutCouncil/MayorCouncillors/Pages/Division5.aspx"
+        }
+      ]
     },
     {
+      "email": "murray.elliott@redland.qld.gov.au",
       "id": "redland_city_council/murray_elliott",
-      "name": "Murray Elliott"
+      "image": "http://www.redland.qld.gov.au/SiteCollectionImages/Council/Councillors%20Mayor/cr-elliott-140-180.jpg",
+      "name": "Murray Elliott",
+      "images": [
+        {
+          "url": "http://www.redland.qld.gov.au/SiteCollectionImages/Council/Councillors%20Mayor/cr-elliott-140-180.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.redland.qld.gov.au/AboutCouncil/MayorCouncillors/Pages/Division7.aspx"
+        }
+      ]
     },
     {
+      "email": "paul.bishop@redland.qld.gov.au",
       "id": "redland_city_council/paul_bishop",
-      "name": "Paul Bishop"
+      "image": "http://www.redland.qld.gov.au/SiteCollectionImages/Council/Councillors%20Mayor/Councillor_Bishop_WEB.jpg",
+      "name": "Paul Bishop",
+      "images": [
+        {
+          "url": "http://www.redland.qld.gov.au/SiteCollectionImages/Council/Councillors%20Mayor/Councillor_Bishop_WEB.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.redland.qld.gov.au/AboutCouncil/MayorCouncillors/Pages/Division10.aspx"
+        }
+      ]
     },
     {
+      "email": "paul.gleeson@redland.qld.gov.au",
       "id": "redland_city_council/paul_gleeson",
-      "name": "Paul Gleeson"
+      "image": "http://www.redland.qld.gov.au/SiteCollectionImages/Council/Councillors%20Mayor/Councillor_Gleeson_WEB.jpg",
+      "name": "Paul Gleeson",
+      "images": [
+        {
+          "url": "http://www.redland.qld.gov.au/SiteCollectionImages/Council/Councillors%20Mayor/Councillor_Gleeson_WEB.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.redland.qld.gov.au/AboutCouncil/MayorCouncillors/Pages/Division9.aspx"
+        }
+      ]
     },
     {
+      "email": "wendy.boglary@redland.qld.gov.au",
       "id": "redland_city_council/wendy_boglary",
-      "name": "Wendy Boglary"
+      "image": "http://www.redland.qld.gov.au/SiteCollectionImages/Council/Councillors%20Mayor/cr-boglary-140-180.jpg",
+      "name": "Wendy Boglary",
+      "images": [
+        {
+          "url": "http://www.redland.qld.gov.au/SiteCollectionImages/Council/Councillors%20Mayor/cr-boglary-140-180.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.redland.qld.gov.au/AboutCouncil/MayorCouncillors/Pages/Division1.aspx"
+        }
+      ]
+    },
+    {
+      "id": "richmond_shire_council/john_wharton",
+      "name": "John Wharton"
+    },
+    {
+      "id": "richmond_shire_council/bethea_pattel",
+      "name": "Bethea Pattel"
+    },
+    {
+      "id": "richmond_shire_council/clay_kennedy",
+      "name": "Clay Kennedy"
+    },
+    {
+      "id": "richmond_shire_council/june_kuhl",
+      "name": "June Kuhl"
+    },
+    {
+      "id": "richmond_shire_council/kevin_bawden",
+      "name": "Kevin Bawden"
+    },
+    {
+      "id": "richmond_shire_council/patsy-ann_fox",
+      "name": "Patsy-Ann Fox"
+    },
+    {
+      "email": "mayor@rrc.qld.gov.au",
+      "id": "rockhampton_regional_council/margaret_strelow",
+      "image": "http://www.rockhamptonregion.qld.gov.au/files/assets/public/councillors/mayorstrelow.jpg",
+      "name": "Margaret Strelow",
+      "images": [
+        {
+          "url": "http://www.rockhamptonregion.qld.gov.au/files/assets/public/councillors/mayorstrelow.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.rockhamptonregion.qld.gov.au/AboutCouncil/Councillors"
+        }
+      ]
+    },
+    {
+      "email": "drew.wickerson@rrc.qld.gov.au",
+      "id": "rockhampton_regional_council/drew_wickerson",
+      "image": "http://www.rockhamptonregion.qld.gov.au/files/assets/public/councillors/dwickerson.png",
+      "name": "Drew Wickerson",
+      "images": [
+        {
+          "url": "http://www.rockhamptonregion.qld.gov.au/files/assets/public/councillors/dwickerson.png"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.rockhamptonregion.qld.gov.au/AboutCouncil/Councillors"
+        }
+      ]
+    },
+    {
+      "email": "cherie.rutherford@rrc.qld.gov.au",
+      "id": "rockhampton_regional_council/cherie_rutherford",
+      "image": "http://www.rockhamptonregion.qld.gov.au/files/assets/public/councillors/picture_crcherierutherford.jpg",
+      "name": "Cherie Rutherford",
+      "images": [
+        {
+          "url": "http://www.rockhamptonregion.qld.gov.au/files/assets/public/councillors/picture_crcherierutherford.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.rockhamptonregion.qld.gov.au/AboutCouncil/Councillors"
+        }
+      ]
+    },
+    {
+      "email": "ellen.smith@rrc.qld.gov.au",
+      "id": "rockhampton_regional_council/ellen_smith",
+      "image": "http://www.rockhamptonregion.qld.gov.au/files/assets/public/councillors/picture_crellensmith.jpg",
+      "name": "Ellen Smith",
+      "images": [
+        {
+          "url": "http://www.rockhamptonregion.qld.gov.au/files/assets/public/councillors/picture_crellensmith.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.rockhamptonregion.qld.gov.au/AboutCouncil/Councillors"
+        }
+      ]
+    },
+    {
+      "email": "neil.fisher@rrc.qld.gov.au",
+      "id": "rockhampton_regional_council/neil_fisher",
+      "image": "http://www.rockhamptonregion.qld.gov.au/files/assets/public/councillors/picture_crneilfisher.jpg",
+      "name": "Neil Fisher",
+      "images": [
+        {
+          "url": "http://www.rockhamptonregion.qld.gov.au/files/assets/public/councillors/picture_crneilfisher.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.rockhamptonregion.qld.gov.au/AboutCouncil/Councillors"
+        }
+      ]
+    },
+    {
+      "email": "rose.swadling@rrc.qld.gov.au",
+      "id": "rockhampton_regional_council/rose_swadling",
+      "image": "http://www.rockhamptonregion.qld.gov.au/files/assets/public/councillors/picture_crroseswadling.jpg",
+      "name": "Rose Swadling",
+      "images": [
+        {
+          "url": "http://www.rockhamptonregion.qld.gov.au/files/assets/public/councillors/picture_crroseswadling.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.rockhamptonregion.qld.gov.au/AboutCouncil/Councillors"
+        }
+      ]
+    },
+    {
+      "email": "stephen.schwarten@rrc.qld.gov.au",
+      "id": "rockhampton_regional_council/stephen_schwarten",
+      "image": "http://www.rockhamptonregion.qld.gov.au/files/assets/public/councillors/picture_crstephenschwarten.jpg",
+      "name": "Stephen Schwarten",
+      "images": [
+        {
+          "url": "http://www.rockhamptonregion.qld.gov.au/files/assets/public/councillors/picture_crstephenschwarten.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.rockhamptonregion.qld.gov.au/AboutCouncil/Councillors"
+        }
+      ]
+    },
+    {
+      "email": "tony.williams@rrc.qld.gov.au",
+      "id": "rockhampton_regional_council/tony_williams",
+      "image": "http://www.rockhamptonregion.qld.gov.au/files/assets/public/councillors/picture_crtonywilliams.jpg",
+      "name": "Tony Williams",
+      "images": [
+        {
+          "url": "http://www.rockhamptonregion.qld.gov.au/files/assets/public/councillors/picture_crtonywilliams.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.rockhamptonregion.qld.gov.au/AboutCouncil/Councillors"
+        }
+      ]
     },
     {
       "id": "scenic_rim_regional_council/john_brent",
       "name": "John Brent"
+    },
+    {
+      "id": "scenic_rim_regional_council/michael_enright",
+      "name": "Michael Enright"
     },
     {
       "id": "scenic_rim_regional_council/duncan_mcinnes",
@@ -2675,8 +2873,16 @@
       "name": "Graeme Lehmann"
     },
     {
-      "id": "somerset_regional_council/alan_bechly",
-      "name": "Alan Bechly"
+      "id": "somerset_regional_council/bob_whalley",
+      "name": "Bob Whalley"
+    },
+    {
+      "id": "somerset_regional_council/cheryl_gaedtke",
+      "name": "Cheryl Gaedtke"
+    },
+    {
+      "id": "somerset_regional_council/sean_choat",
+      "name": "Sean Choat"
     },
     {
       "id": "somerset_regional_council/dan_hall",
@@ -2687,14 +2893,6 @@
       "name": "Helen Brieschke"
     },
     {
-      "id": "somerset_regional_council/jim_madden",
-      "name": "Jim Madden"
-    },
-    {
-      "id": "somerset_regional_council/kirsten_moriarty",
-      "name": "Kirsten Moriarty"
-    },
-    {
       "id": "somerset_regional_council/michael_ogg",
       "name": "Michael Ogg"
     },
@@ -2703,48 +2901,52 @@
       "name": "Wayne Kratzmann"
     },
     {
-      "id": "south_burnett_regional_council/barry_green",
-      "name": "Barry Green"
+      "id": "south_burnett_regional_council/roz_frohloff",
+      "name": "Roz Frohloff"
     },
     {
-      "id": "south_burnett_regional_council/damien_tessmann",
-      "name": "Damien Tessmann"
+      "id": "south_burnett_regional_council/gavin_jones",
+      "name": "Gavin Jones"
     },
     {
-      "id": "south_burnett_regional_council/debra_palmer",
-      "name": "Debra Palmer"
+      "id": "south_burnett_regional_council/danita_potter",
+      "name": "Danita Potter"
+    },
+    {
+      "id": "south_burnett_regional_council/terry_fleischfresser",
+      "name": "Terry Fleischfresser"
     },
     {
       "id": "south_burnett_regional_council/kathy_duff",
       "name": "Kathy Duff"
     },
     {
-      "id": "south_burnett_regional_council/keith_campbell",
-      "name": "Keith Campbell"
-    },
-    {
       "id": "south_burnett_regional_council/ros_heit",
       "name": "Ros Heit"
     },
     {
-      "id": "southern_downs_regional_council/peter_blundell",
-      "name": "Peter Blundell"
+      "id": "southern_downs_regional_council/tracy_dobie",
+      "name": "Tracy Dobie"
+    },
+    {
+      "id": "southern_downs_regional_council/sheryl_windle",
+      "name": "Sheryl Windle"
+    },
+    {
+      "id": "southern_downs_regional_council/rod_kelly",
+      "name": "Rod Kelly"
+    },
+    {
+      "id": "southern_downs_regional_council/marika_mcnichol",
+      "name": "Marika McNichol"
+    },
+    {
+      "id": "southern_downs_regional_council/yve_stocks",
+      "name": "Yve Stocks"
     },
     {
       "id": "southern_downs_regional_council/cameron_gow",
       "name": "Cameron Gow"
-    },
-    {
-      "id": "southern_downs_regional_council/denise_ingram",
-      "name": "Denise Ingram"
-    },
-    {
-      "id": "southern_downs_regional_council/glyn_rees",
-      "name": "Glyn Rees"
-    },
-    {
-      "id": "southern_downs_regional_council/jamie_mackenzie",
-      "name": "Jamie Mackenzie"
     },
     {
       "id": "southern_downs_regional_council/jo_mcnally",
@@ -2753,10 +2955,6 @@
     {
       "id": "southern_downs_regional_council/neil_meiklejohn",
       "name": "Neil Meiklejohn"
-    },
-    {
-      "id": "southern_downs_regional_council/ross_bartley",
-      "name": "Ross Bartley"
     },
     {
       "id": "southern_downs_regional_council/vic_pennisi",
@@ -2939,6 +3137,67 @@
       ]
     },
     {
+      "id": "tablelands_regional_council/joe_paronella",
+      "name": "Joe Paronella"
+    },
+    {
+      "id": "tablelands_regional_council/kate_eden",
+      "name": "Kate Eden"
+    },
+    {
+      "id": "tablelands_regional_council/annette_haydon",
+      "name": "Annette Haydon"
+    },
+    {
+      "id": "tablelands_regional_council/anthony_ball",
+      "name": "Anthony Ball"
+    },
+    {
+      "id": "tablelands_regional_council/samantha_banks",
+      "name": "Samantha Banks"
+    },
+    {
+      "id": "tablelands_regional_council/katrina_spies",
+      "name": "Katrina Spies"
+    },
+    {
+      "id": "tablelands_regional_council/bronwyn_voyce",
+      "name": "Bronwyn Voyce"
+    },
+    {
+      "email": "joe.ramia@tr.qld.gov.au",
+      "id": "toowoomba_regional_council/joe_ramia",
+      "image": "http://www.tr.qld.gov.au/images/200-aboutCouncil/230-councillorsMeetings/231-introducingCouncillors/JoeRamiaheadshot.jpg",
+      "name": "Joe Ramia",
+      "images": [
+        {
+          "url": "http://www.tr.qld.gov.au/images/200-aboutCouncil/230-councillorsMeetings/231-introducingCouncillors/JoeRamiaheadshot.jpg"
+        }
+      ]
+    },
+    {
+      "email": "Megan.O'HaraSullivan@tr.qld.gov.au",
+      "id": "toowoomba_regional_council/megan_o'hara_sullivan",
+      "image": "http://www.tr.qld.gov.au/images/200-aboutCouncil/230-councillorsMeetings/231-introducingCouncillors/MeganOHaraSullivanheadshot2016.jpg",
+      "name": "Megan O'Hara Sullivan",
+      "images": [
+        {
+          "url": "http://www.tr.qld.gov.au/images/200-aboutCouncil/230-councillorsMeetings/231-introducingCouncillors/MeganOHaraSullivanheadshot2016.jpg"
+        }
+      ]
+    },
+    {
+      "email": "james.oshea@tr.qld.gov.au",
+      "id": "toowoomba_regional_council/james_o'shea",
+      "image": "http://www.tr.qld.gov.au/images/200-aboutCouncil/230-councillorsMeetings/231-introducingCouncillors/JamesOSheaheadshot.jpg",
+      "name": "James O'Shea",
+      "images": [
+        {
+          "url": "http://www.tr.qld.gov.au/images/200-aboutCouncil/230-councillorsMeetings/231-introducingCouncillors/JamesOSheaheadshot.jpg"
+        }
+      ]
+    },
+    {
       "email": "paul.antonio@tr.qld.gov.au",
       "id": "toowoomba_regional_council/paul_antonio",
       "image": "https://ia801505.us.archive.org/24/items/australian_local_councillor_images/2016-01-04%20Toowoomba%20Councillors/paul_antonio-320px.jpg",
@@ -3005,17 +3264,6 @@
       ]
     },
     {
-      "email": "john.gouldson@tr.qld.gov.au",
-      "id": "toowoomba_regional_council/john_gouldson",
-      "image": "https://ia801505.us.archive.org/24/items/australian_local_councillor_images/2016-01-04%20Toowoomba%20Councillors/john_gouldson-320px.jpg",
-      "name": "John Gouldson",
-      "images": [
-        {
-          "url": "https://ia801505.us.archive.org/24/items/australian_local_councillor_images/2016-01-04%20Toowoomba%20Councillors/john_gouldson-320px.jpg"
-        }
-      ]
-    },
-    {
       "email": "mike.williams@tr.qld.gov.au",
       "id": "toowoomba_regional_council/mike_williams",
       "image": "https://ia801505.us.archive.org/24/items/australian_local_councillor_images/2016-01-04%20Toowoomba%20Councillors/mike_williams-320px.jpg",
@@ -3038,30 +3286,280 @@
       ]
     },
     {
-      "email": "ros.scotney@tr.qld.gov.au",
-      "id": "toowoomba_regional_council/roslyn_scotney",
-      "image": "https://ia801505.us.archive.org/24/items/australian_local_councillor_images/2016-01-04%20Toowoomba%20Councillors/ros_scotney-320px.jpg",
-      "name": "Roslyn Scotney",
+      "id": "torres_shire_council/vonda_malone",
+      "name": "Vonda Malone"
+    },
+    {
+      "id": "torres_shire_council/gabriel_bani",
+      "name": "Gabriel Bani"
+    },
+    {
+      "id": "torres_shire_council/thomas_loban",
+      "name": "Thomas Loban"
+    },
+    {
+      "id": "torres_shire_council/john_abednego",
+      "name": "John Abednego"
+    },
+    {
+      "id": "torres_shire_council/yen_loban",
+      "name": "Yen Loban"
+    },
+    {
+      "id": "torres_strait_island_regional_council/fred_gela",
+      "name": "Fred Gela"
+    },
+    {
+      "id": "torres_strait_island_regional_council/torenzo_elisala",
+      "name": "Torenzo Elisala"
+    },
+    {
+      "id": "torres_strait_island_regional_council/nona_laurie",
+      "name": "Nona Laurie"
+    },
+    {
+      "id": "torres_strait_island_regional_council/john_levi",
+      "name": "John Levi"
+    },
+    {
+      "id": "torres_strait_island_regional_council/clara_tamu",
+      "name": "Clara Tamu"
+    },
+    {
+      "id": "torres_strait_island_regional_council/francis_pearson",
+      "name": "Francis Pearson"
+    },
+    {
+      "id": "torres_strait_island_regional_council/fraser_nai",
+      "name": "Fraser Nai"
+    },
+    {
+      "id": "torres_strait_island_regional_council/patrick_thaiday",
+      "name": "Patrick Thaiday"
+    },
+    {
+      "id": "torres_strait_island_regional_council/bob_kaigey",
+      "name": "Bob Kaigey"
+    },
+    {
+      "id": "torres_strait_island_regional_council/david_bosun",
+      "name": "David Bosun"
+    },
+    {
+      "id": "torres_strait_island_regional_council/dimas_toby",
+      "name": "Dimas Toby"
+    },
+    {
+      "id": "torres_strait_island_regional_council/getano_lui",
+      "name": "Getano Lui"
+    },
+    {
+      "id": "torres_strait_island_regional_council/rocky_stephen",
+      "name": "Rocky Stephen"
+    },
+    {
+      "id": "torres_strait_island_regional_council/keith_fell",
+      "name": "Keith Fell"
+    },
+    {
+      "id": "torres_strait_island_regional_council/mario_sabatino",
+      "name": "Mario Sabatino"
+    },
+    {
+      "id": "torres_strait_island_regional_council/ron_enosa",
+      "name": "Ron Enosa"
+    },
+    {
+      "email": "Mayor@townsville.qld.gov.au",
+      "id": "townsville_city_council/jenny_hill",
+      "image": "https://www.townsville.qld.gov.au/__data/assets/image/0021/3288/Image-of-Mayor-Jenny-Hill.jpg",
+      "name": "Jenny Hill",
       "images": [
         {
-          "url": "https://ia801505.us.archive.org/24/items/australian_local_councillor_images/2016-01-04%20Toowoomba%20Councillors/ros_scotney-320px.jpg"
+          "url": "https://www.townsville.qld.gov.au/__data/assets/image/0021/3288/Image-of-Mayor-Jenny-Hill.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "https://www.townsville.qld.gov.au/about-council/mayor-and-councillors/councillor-profiles/cr-jenny-hill"
         }
       ]
     },
     {
-      "email": "sue.englart@tr.qld.gov.au",
-      "id": "toowoomba_regional_council/sue_englart",
-      "image": "https://ia801505.us.archive.org/24/items/australian_local_councillor_images/2016-01-04%20Toowoomba%20Councillors/sue_englart-320px.jpg",
-      "name": "Sue Englart",
+      "email": "Margie.Ryder@townsville.qld.gov.au",
+      "id": "townsville_city_council/margie_ryder",
+      "image": "https://www.townsville.qld.gov.au/__data/assets/image/0025/12895/margie-ryder.png",
+      "name": "Margie Ryder",
       "images": [
         {
-          "url": "https://ia801505.us.archive.org/24/items/australian_local_councillor_images/2016-01-04%20Toowoomba%20Councillors/sue_englart-320px.jpg"
+          "url": "https://www.townsville.qld.gov.au/__data/assets/image/0025/12895/margie-ryder.png"
+        }
+      ],
+      "sources": [
+        {
+          "url": "https://www.townsville.qld.gov.au/about-council/mayor-and-councillors/councillor-profiles/cr-margie-ryder"
         }
       ]
     },
     {
-      "id": "western_downs_regional_council/raymond_brown",
-      "name": "Raymond Brown"
+      "email": "Paul.Jacob@townsville.qld.gov.au",
+      "id": "townsville_city_council/paul_jacob",
+      "image": "https://www.townsville.qld.gov.au/__data/assets/image/0028/12898/paul-jacob.png",
+      "name": "Paul Jacob",
+      "images": [
+        {
+          "url": "https://www.townsville.qld.gov.au/__data/assets/image/0028/12898/paul-jacob.png"
+        }
+      ],
+      "sources": [
+        {
+          "url": "https://www.townsville.qld.gov.au/about-council/mayor-and-councillors/councillor-profiles/cr-paul-jacob"
+        }
+      ]
+    },
+    {
+      "email": "Ann-Maree.Greaney@townsville.qld.gov.au",
+      "id": "townsville_city_council/ann-maree_greaney",
+      "image": "https://www.townsville.qld.gov.au/__data/assets/image/0023/12893/ann-maree-greaney.png",
+      "name": "Ann-Maree Greaney",
+      "images": [
+        {
+          "url": "https://www.townsville.qld.gov.au/__data/assets/image/0023/12893/ann-maree-greaney.png"
+        }
+      ],
+      "sources": [
+        {
+          "url": "https://www.townsville.qld.gov.au/about-council/mayor-and-councillors/councillor-profiles/cr-ann-maree-greaney"
+        }
+      ]
+    },
+    {
+      "email": "Mark.Molachino@townsville.qld.gov.au",
+      "id": "townsville_city_council/mark_molachino",
+      "image": "https://www.townsville.qld.gov.au/__data/assets/image/0026/12896/mark-molochino.png",
+      "name": "Mark Molachino",
+      "images": [
+        {
+          "url": "https://www.townsville.qld.gov.au/__data/assets/image/0026/12896/mark-molochino.png"
+        }
+      ],
+      "sources": [
+        {
+          "url": "https://www.townsville.qld.gov.au/about-council/mayor-and-councillors/councillor-profiles/cr-mark-molachino"
+        }
+      ]
+    },
+    {
+      "email": "Russ.Cook@townsville.qld.gov.au",
+      "id": "townsville_city_council/russ_cook",
+      "image": "https://www.townsville.qld.gov.au/__data/assets/image/0029/12899/russ-cook.png",
+      "name": "Russ Cook",
+      "images": [
+        {
+          "url": "https://www.townsville.qld.gov.au/__data/assets/image/0029/12899/russ-cook.png"
+        }
+      ],
+      "sources": [
+        {
+          "url": "https://www.townsville.qld.gov.au/about-council/mayor-and-councillors/councillor-profiles/cr-russ-cook"
+        }
+      ]
+    },
+    {
+      "email": "Verena.Coombe@townsville.qld.gov.au",
+      "id": "townsville_city_council/verena_coombe",
+      "image": "https://www.townsville.qld.gov.au/__data/assets/image/0012/12900/verena-coombe.png",
+      "name": "Verena Coombe",
+      "images": [
+        {
+          "url": "https://www.townsville.qld.gov.au/__data/assets/image/0012/12900/verena-coombe.png"
+        }
+      ],
+      "sources": [
+        {
+          "url": "https://www.townsville.qld.gov.au/about-council/mayor-and-councillors/councillor-profiles/cr-verena-coombe"
+        }
+      ]
+    },
+    {
+      "email": "Kurt.Rehbein@townsville.qld.gov.au",
+      "id": "townsville_city_council/kurt_rehbein",
+      "image": "https://www.townsville.qld.gov.au/__data/assets/image/0024/12894/kurt-rehbein.png",
+      "name": "Kurt Rehbein",
+      "images": [
+        {
+          "url": "https://www.townsville.qld.gov.au/__data/assets/image/0024/12894/kurt-rehbein.png"
+        }
+      ],
+      "sources": [
+        {
+          "url": "https://www.townsville.qld.gov.au/about-council/mayor-and-councillors/councillor-profiles/cr-kurt-rehbein"
+        }
+      ]
+    },
+    {
+      "email": "Maurie.Soars@townsville.qld.gov.au",
+      "id": "townsville_city_council/maurie_soars",
+      "image": "https://www.townsville.qld.gov.au/__data/assets/image/0027/12897/maurie-soars.png",
+      "name": "Maurie Soars",
+      "images": [
+        {
+          "url": "https://www.townsville.qld.gov.au/__data/assets/image/0027/12897/maurie-soars.png"
+        }
+      ],
+      "sources": [
+        {
+          "url": "https://www.townsville.qld.gov.au/about-council/mayor-and-councillors/councillor-profiles/cr-maurie-soars"
+        }
+      ]
+    },
+    {
+      "email": "colleen.doyle@townsville.qld.gov.au",
+      "id": "townsville_city_council/colleen_doyle",
+      "image": "https://www.townsville.qld.gov.au/__data/assets/image/0008/3302/colleen-doyle.png",
+      "name": "Colleen Doyle",
+      "images": [
+        {
+          "url": "https://www.townsville.qld.gov.au/__data/assets/image/0008/3302/colleen-doyle.png"
+        }
+      ],
+      "sources": [
+        {
+          "url": "https://www.townsville.qld.gov.au/about-council/mayor-and-councillors/councillor-profiles/cr-colleen-doyle"
+        }
+      ]
+    },
+    {
+      "email": "cr.les.walker@townsville.qld.gov.au",
+      "id": "townsville_city_council/les_walker",
+      "image": "https://www.townsville.qld.gov.au/__data/assets/image/0010/3313/les-walker.png",
+      "name": "Les Walker",
+      "images": [
+        {
+          "url": "https://www.townsville.qld.gov.au/__data/assets/image/0010/3313/les-walker.png"
+        }
+      ],
+      "sources": [
+        {
+          "url": "https://www.townsville.qld.gov.au/about-council/mayor-and-councillors/councillor-profiles/cr-les-walker"
+        }
+      ]
+    },
+    {
+      "id": "western_downs_regional_council/paul_mcveigh",
+      "name": "Paul McVeigh"
+    },
+    {
+      "id": "western_downs_regional_council/peter_saxelby",
+      "name": "Peter Saxelby"
+    },
+    {
+      "id": "western_downs_regional_council/kaye_maguire",
+      "name": "Kaye Maguire"
+    },
+    {
+      "id": "western_downs_regional_council/donna_ashurst",
+      "name": "Donna Ashurst"
     },
     {
       "id": "western_downs_regional_council/andrew_smith",
@@ -3072,14 +3570,6 @@
       "name": "Carolyn Tillman"
     },
     {
-      "id": "western_downs_regional_council/charlene_hall",
-      "name": "Charlene Hall"
-    },
-    {
-      "id": "western_downs_regional_council/george_moore",
-      "name": "George Moore"
-    },
-    {
       "id": "western_downs_regional_council/greg_olm",
       "name": "Greg Olm"
     },
@@ -3088,71 +3578,133 @@
       "name": "Ian Rassmussen"
     },
     {
-      "id": "western_downs_regional_council/raymond_jamieson",
-      "name": "Raymond Jamieson"
+      "id": "western_downs_regional_council/raymond_brown",
+      "name": "Raymond Brown"
     },
     {
-      "id": "western_downs_regional_council/tony_brame",
-      "name": "Tony Brame"
+      "id": "whitsunday_regional_council/andrew_willcox",
+      "name": "Andrew Willcox"
     },
     {
-      "id": "livingstone_shire_council/bill_ludwig",
-      "name": "Bill Ludwig"
+      "id": "whitsunday_regional_council/ron_petterson",
+      "name": "Ron Petterson"
     },
     {
-      "id": "livingstone_shire_council/adam_belot",
-      "name": "Adam Belot"
+      "id": "whitsunday_regional_council/mike_brunker",
+      "name": "Mike Brunker"
     },
     {
-      "id": "livingstone_shire_council/glenda_mather",
-      "name": "Glenda Mather"
+      "id": "whitsunday_regional_council/dave_clark",
+      "name": "Dave Clark"
     },
     {
-      "id": "livingstone_shire_council/graham_scott",
-      "name": "Graham Scott"
+      "id": "whitsunday_regional_council/jan_clifford",
+      "name": "Jan Clifford"
     },
     {
-      "id": "livingstone_shire_council/jan_kelly",
-      "name": "Jan Kelly"
+      "id": "whitsunday_regional_council/john_collins",
+      "name": "John Collins"
     },
     {
-      "id": "livingstone_shire_council/nigel_hutton",
-      "name": "Nigel Hutton"
+      "id": "whitsunday_regional_council/peter_ramage",
+      "name": "Peter Ramage"
     },
     {
-      "id": "livingstone_shire_council/tom_wyatt",
-      "name": "Tom Wyatt"
+      "id": "winton_shire_council/butch_lenton",
+      "name": "Butch Lenton"
     },
     {
-      "id": "noosa_shire_council/noel_playford",
-      "name": "Noel Playford"
+      "id": "winton_shire_council/joel_mann",
+      "name": "Joel Mann"
     },
     {
-      "id": "noosa_shire_council/bob_abbott",
-      "name": "Bob Abbott"
+      "id": "winton_shire_council/travis_harbour",
+      "name": "Travis Harbour"
     },
     {
-      "id": "noosa_shire_council/frank_pardon",
-      "name": "Frank Pardon"
+      "id": "winton_shire_council/gavin_baskett",
+      "name": "Gavin Baskett"
     },
     {
-      "id": "noosa_shire_council/frank_wilkie",
-      "name": "Frank Wilkie"
+      "id": "winton_shire_council/judy_sale",
+      "name": "Judy Sale"
     },
     {
-      "id": "noosa_shire_council/joe_jurisevic",
-      "name": "Joe Jurisevic"
+      "id": "winton_shire_council/shane_mann",
+      "name": "Shane Mann"
     },
     {
-      "id": "noosa_shire_council/sandy_bolton",
-      "name": "Sandy Bolton"
+      "id": "woorabinda_aboriginal_shire_council/shane_wilkie",
+      "name": "Shane Wilkie"
     },
     {
-      "id": "noosa_shire_council/tony_wellington",
-      "name": "Tony Wellington"
+      "id": "woorabinda_aboriginal_shire_council/stewart_smith",
+      "name": "Stewart Smith"
+    },
+    {
+      "id": "woorabinda_aboriginal_shire_council/laurence_weazel",
+      "name": "Laurence Weazel"
+    },
+    {
+      "id": "woorabinda_aboriginal_shire_council/phillip_alberts",
+      "name": "Phillip Alberts"
+    },
+    {
+      "id": "woorabinda_aboriginal_shire_council/archie_williams",
+      "name": "Archie Williams"
+    },
+    {
+      "id": "wujal_wujal_aboriginal_shire_council/clifford_harrigan",
+      "name": "Clifford Harrigan"
+    },
+    {
+      "id": "wujal_wujal_aboriginal_shire_council/robert_bloomfield",
+      "name": "Robert Bloomfield"
+    },
+    {
+      "id": "wujal_wujal_aboriginal_shire_council/bradley_creek",
+      "name": "Bradley Creek"
+    },
+    {
+      "id": "wujal_wujal_aboriginal_shire_council/bobby_kulka",
+      "name": "Bobby Kulka"
+    },
+    {
+      "id": "wujal_wujal_aboriginal_shire_council/vincent_tayley",
+      "name": "Vincent Tayley"
+    },
+    {
+      "id": "yarrabah_aboriginal_shire_council/ross_andrews",
+      "name": "Ross Andrews"
+    },
+    {
+      "id": "yarrabah_aboriginal_shire_council/nadine_cannon",
+      "name": "Nadine Cannon"
+    },
+    {
+      "id": "yarrabah_aboriginal_shire_council/colin_cedric",
+      "name": "Colin Cedric"
+    },
+    {
+      "id": "yarrabah_aboriginal_shire_council/ian_patterson",
+      "name": "Ian Patterson"
+    },
+    {
+      "id": "yarrabah_aboriginal_shire_council/michael_sands",
+      "name": "Michael Sands"
     }
   ],
   "organizations": [
+    {
+      "id": "legislature/aurukun_shire_council",
+      "name": "Aurukun Shire Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/balonne_shire_council",
+      "name": "Balonne Shire Council",
+      "classification": "legislature"
+    },
     {
       "id": "legislature/banana_shire_council",
       "name": "Banana Shire Council",
@@ -3179,58 +3731,18 @@
       "classification": "legislature"
     },
     {
-      "id": "legislature/central_highlands_regional_council",
-      "name": "Central Highlands Regional Council",
+      "id": "legislature/brisbane_city_council",
+      "name": "Brisbane City Council",
       "classification": "legislature"
     },
     {
-      "id": "legislature/diamantina_shire_council",
-      "name": "Diamantina Shire Council",
+      "id": "legislature/bulloo_shire_council",
+      "name": "Bulloo Shire Council",
       "classification": "legislature"
     },
     {
-      "id": "legislature/gladstone_regional_council",
-      "name": "Gladstone Regional Council",
-      "classification": "legislature"
-    },
-    {
-      "id": "legislature/isaac_regional_council",
-      "name": "Isaac Regional Council",
-      "classification": "legislature"
-    },
-    {
-      "id": "legislature/longreach_regional_council",
-      "name": "Longreach Regional Council",
-      "classification": "legislature"
-    },
-    {
-      "id": "legislature/mackay_regional_council",
-      "name": "Mackay Regional Council",
-      "classification": "legislature"
-    },
-    {
-      "id": "legislature/rockhampton_regional_council",
-      "name": "Rockhampton Regional Council",
-      "classification": "legislature"
-    },
-    {
-      "id": "legislature/whitsunday_regional_council",
-      "name": "Whitsunday Regional Council",
-      "classification": "legislature"
-    },
-    {
-      "id": "legislature/winton_shire_council",
-      "name": "Winton Shire Council",
-      "classification": "legislature"
-    },
-    {
-      "id": "legislature/woorabinda_aboriginal_shire_council",
-      "name": "Woorabinda Aboriginal Shire Council",
-      "classification": "legislature"
-    },
-    {
-      "id": "legislature/aurukun_shire_council",
-      "name": "Aurukun Shire Council",
+      "id": "legislature/bundaberg_regional_council",
+      "name": "Bundaberg Regional Council",
       "classification": "legislature"
     },
     {
@@ -3259,8 +3771,18 @@
       "classification": "legislature"
     },
     {
+      "id": "legislature/central_highlands_regional_council",
+      "name": "Central Highlands Regional Council",
+      "classification": "legislature"
+    },
+    {
       "id": "legislature/charters_towers_regional_council",
       "name": "Charters Towers Regional Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/cherbourg_aboriginal_shire_council",
+      "name": "Cherbourg Aboriginal Shire Council",
       "classification": "legislature"
     },
     {
@@ -3279,8 +3801,18 @@
       "classification": "legislature"
     },
     {
+      "id": "legislature/diamantina_shire_council",
+      "name": "Diamantina Shire Council",
+      "classification": "legislature"
+    },
+    {
       "id": "legislature/doomadgee_aboriginal_shire_council",
       "name": "Doomadgee Aboriginal Shire Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/douglas_shire_council",
+      "name": "Douglas Shire Council",
       "classification": "legislature"
     },
     {
@@ -3294,138 +3826,13 @@
       "classification": "legislature"
     },
     {
-      "id": "legislature/hinchinbrook_shire_council",
-      "name": "Hinchinbrook Shire Council",
-      "classification": "legislature"
-    },
-    {
-      "id": "legislature/hope_vale_aboriginal_shire_council",
-      "name": "Hope Vale Aboriginal Shire Council",
-      "classification": "legislature"
-    },
-    {
-      "id": "legislature/kowanyama_aboriginal_shire_council",
-      "name": "Kowanyama Aboriginal Shire Council",
-      "classification": "legislature"
-    },
-    {
-      "id": "legislature/lockhart_river_aboriginal_shire_council",
-      "name": "Lockhart River Aboriginal Shire Council",
-      "classification": "legislature"
-    },
-    {
-      "id": "legislature/mapoon_aboriginal_shire_council",
-      "name": "Mapoon Aboriginal Shire Council",
-      "classification": "legislature"
-    },
-    {
-      "id": "legislature/mckinlay_shire_council",
-      "name": "McKinlay Shire Council",
-      "classification": "legislature"
-    },
-    {
-      "id": "legislature/mornington_shire_council",
-      "name": "Mornington Shire Council",
-      "classification": "legislature"
-    },
-    {
-      "id": "legislature/mount_isa_city_council",
-      "name": "Mount Isa City Council",
-      "classification": "legislature"
-    },
-    {
-      "id": "legislature/napranum_aboriginal_shire_council",
-      "name": "Napranum Aboriginal Shire Council",
-      "classification": "legislature"
-    },
-    {
-      "id": "legislature/northern_peninsula_area_regional_council",
-      "name": "Northern Peninsula Area Regional Council",
-      "classification": "legislature"
-    },
-    {
-      "id": "legislature/palm_island_aboriginal_shire_council",
-      "name": "Palm Island Aboriginal Shire Council",
-      "classification": "legislature"
-    },
-    {
-      "id": "legislature/pormpuraaw_aboriginal_shire_council",
-      "name": "Pormpuraaw Aboriginal Shire Council",
-      "classification": "legislature"
-    },
-    {
-      "id": "legislature/richmond_shire_council",
-      "name": "Richmond Shire Council",
-      "classification": "legislature"
-    },
-    {
-      "id": "legislature/tablelands_regional_council",
-      "name": "Tablelands Regional Council",
-      "classification": "legislature"
-    },
-    {
-      "id": "legislature/torres_shire_council",
-      "name": "Torres Shire Council",
-      "classification": "legislature"
-    },
-    {
-      "id": "legislature/torres_strait_island_regional_council",
-      "name": "Torres Strait Island Regional Council",
-      "classification": "legislature"
-    },
-    {
-      "id": "legislature/townsville_city_council",
-      "name": "Townsville City Council",
-      "classification": "legislature"
-    },
-    {
-      "id": "legislature/wujal_wujal_aboriginal_shire_council",
-      "name": "Wujal Wujal Aboriginal Shire Council",
-      "classification": "legislature"
-    },
-    {
-      "id": "legislature/yarrabah_aboriginal_shire_council",
-      "name": "Yarrabah Aboriginal Shire Council",
-      "classification": "legislature"
-    },
-    {
-      "id": "legislature/douglas_shire_council",
-      "name": "Douglas Shire Council",
-      "classification": "legislature"
-    },
-    {
-      "id": "legislature/mareeba_shire_council",
-      "name": "Mareeba Shire Council",
-      "classification": "legislature"
-    },
-    {
-      "id": "legislature/balonne_shire_council",
-      "name": "Balonne Shire Council",
-      "classification": "legislature"
-    },
-    {
-      "id": "legislature/brisbane_city_council",
-      "name": "Brisbane City Council",
-      "classification": "legislature"
-    },
-    {
-      "id": "legislature/bulloo_shire_council",
-      "name": "Bulloo Shire Council",
-      "classification": "legislature"
-    },
-    {
-      "id": "legislature/bundaberg_regional_council",
-      "name": "Bundaberg Regional Council",
-      "classification": "legislature"
-    },
-    {
-      "id": "legislature/cherbourg_aboriginal_shire_council",
-      "name": "Cherbourg Aboriginal Shire Council",
-      "classification": "legislature"
-    },
-    {
       "id": "legislature/fraser_coast_regional_council",
       "name": "Fraser Coast Regional Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/gladstone_regional_council",
+      "name": "Gladstone Regional Council",
       "classification": "legislature"
     },
     {
@@ -3444,8 +3851,38 @@
       "classification": "legislature"
     },
     {
+      "id": "legislature/hinchinbrook_shire_council",
+      "name": "Hinchinbrook Shire Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/hope_vale_aboriginal_shire_council",
+      "name": "Hope Vale Aboriginal Shire Council",
+      "classification": "legislature"
+    },
+    {
       "id": "legislature/ipswich_city_council",
       "name": "Ipswich City Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/isaac_regional_council",
+      "name": "Isaac Regional Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/kowanyama_aboriginal_shire_council",
+      "name": "Kowanyama Aboriginal Shire Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/livingstone_shire_council",
+      "name": "Livingstone Shire Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/lockhart_river_aboriginal_shire_council",
+      "name": "Lockhart River Aboriginal Shire Council",
       "classification": "legislature"
     },
     {
@@ -3459,8 +3896,33 @@
       "classification": "legislature"
     },
     {
+      "id": "legislature/longreach_regional_council",
+      "name": "Longreach Regional Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/mackay_regional_council",
+      "name": "Mackay Regional Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/mapoon_aboriginal_shire_council",
+      "name": "Mapoon Aboriginal Shire Council",
+      "classification": "legislature"
+    },
+    {
       "id": "legislature/maranoa_regional_council",
       "name": "Maranoa Regional Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/mareeba_shire_council",
+      "name": "Mareeba Shire Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/mckinlay_shire_council",
+      "name": "McKinlay Shire Council",
       "classification": "legislature"
     },
     {
@@ -3469,8 +3931,28 @@
       "classification": "legislature"
     },
     {
+      "id": "legislature/mornington_shire_council",
+      "name": "Mornington Shire Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/mount_isa_city_council",
+      "name": "Mount Isa City Council",
+      "classification": "legislature"
+    },
+    {
       "id": "legislature/murweh_shire_council",
       "name": "Murweh Shire Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/napranum_aboriginal_shire_council",
+      "name": "Napranum Aboriginal Shire Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/noosa_shire_council",
+      "name": "Noosa Shire Council",
       "classification": "legislature"
     },
     {
@@ -3479,8 +3961,23 @@
       "classification": "legislature"
     },
     {
+      "id": "legislature/northern_peninsula_area_regional_council",
+      "name": "Northern Peninsula Area Regional Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/palm_island_aboriginal_shire_council",
+      "name": "Palm Island Aboriginal Shire Council",
+      "classification": "legislature"
+    },
+    {
       "id": "legislature/paroo_shire_council",
       "name": "Paroo Shire Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/pormpuraaw_aboriginal_shire_council",
+      "name": "Pormpuraaw Aboriginal Shire Council",
       "classification": "legislature"
     },
     {
@@ -3491,6 +3988,16 @@
     {
       "id": "legislature/redland_city_council",
       "name": "Redland City Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/richmond_shire_council",
+      "name": "Richmond Shire Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/rockhampton_regional_council",
+      "name": "Rockhampton Regional Council",
       "classification": "legislature"
     },
     {
@@ -3519,8 +4026,28 @@
       "classification": "legislature"
     },
     {
+      "id": "legislature/tablelands_regional_council",
+      "name": "Tablelands Regional Council",
+      "classification": "legislature"
+    },
+    {
       "id": "legislature/toowoomba_regional_council",
       "name": "Toowoomba Regional Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/torres_shire_council",
+      "name": "Torres Shire Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/torres_strait_island_regional_council",
+      "name": "Torres Strait Island Regional Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/townsville_city_council",
+      "name": "Townsville City Council",
       "classification": "legislature"
     },
     {
@@ -3529,13 +4056,28 @@
       "classification": "legislature"
     },
     {
-      "id": "legislature/livingstone_shire_council",
-      "name": "Livingstone Shire Council",
+      "id": "legislature/whitsunday_regional_council",
+      "name": "Whitsunday Regional Council",
       "classification": "legislature"
     },
     {
-      "id": "legislature/noosa_shire_council",
-      "name": "Noosa Shire Council",
+      "id": "legislature/winton_shire_council",
+      "name": "Winton Shire Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/woorabinda_aboriginal_shire_council",
+      "name": "Woorabinda Aboriginal Shire Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/wujal_wujal_aboriginal_shire_council",
+      "name": "Wujal Wujal Aboriginal Shire Council",
+      "classification": "legislature"
+    },
+    {
+      "id": "legislature/yarrabah_aboriginal_shire_council",
+      "name": "Yarrabah Aboriginal Shire Council",
       "classification": "legislature"
     },
     {
@@ -3544,8 +4086,8 @@
       "classification": "party"
     },
     {
-      "id": "party/team_jenny_hill",
-      "name": "Team Jenny Hill",
+      "id": "party/team_mcmillan",
+      "name": "Team McMillan",
       "classification": "party"
     },
     {
@@ -3557,29 +4099,106 @@
       "id": "party/independent",
       "name": "Independent",
       "classification": "party"
+    },
+    {
+      "id": "party/team_jenny_hill",
+      "name": "Team Jenny Hill",
+      "classification": "party"
     }
   ],
   "memberships": [
     {
-      "person_id": "banana_shire_council/ron_carige",
+      "person_id": "aurukun_shire_council/dereck_walpo",
+      "organization_id": "legislature/aurukun_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "aurukun_shire_council/doris_poonkamelya",
+      "organization_id": "legislature/aurukun_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "aurukun_shire_council/ada_woolla",
+      "organization_id": "legislature/aurukun_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "aurukun_shire_council/edgar_kerindun",
+      "organization_id": "legislature/aurukun_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "aurukun_shire_council/vera_komeeta",
+      "organization_id": "legislature/aurukun_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "balonne_shire_council/richard_marsh",
+      "organization_id": "legislature/balonne_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "balonne_shire_council/samantha_o'toole",
+      "organization_id": "legislature/balonne_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "balonne_shire_council/scott_scriven",
+      "organization_id": "legislature/balonne_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "balonne_shire_council/robyn_fuhrmeister",
+      "organization_id": "legislature/balonne_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "balonne_shire_council/ian_todd",
+      "organization_id": "legislature/balonne_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "balonne_shire_council/fiona_gaske",
+      "organization_id": "legislature/balonne_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "balonne_shire_council/robert_paul",
+      "organization_id": "legislature/balonne_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "banana_shire_council/nev_ferrier",
+      "organization_id": "legislature/banana_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "banana_shire_council/colin_semple",
+      "organization_id": "legislature/banana_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "banana_shire_council/brooke_leo",
       "organization_id": "legislature/banana_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
       "person_id": "banana_shire_council/david_snell",
-      "organization_id": "legislature/banana_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "banana_shire_council/maureen_clancy",
-      "organization_id": "legislature/banana_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "banana_shire_council/nev_ferrier",
       "organization_id": "legislature/banana_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
@@ -3609,7 +4228,19 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "barcaldine_regional_council/andrew_cowper",
+      "person_id": "barcaldine_regional_council/sean_dillon",
+      "organization_id": "legislature/barcaldine_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "barcaldine_regional_council/milynda_rogers",
+      "organization_id": "legislature/barcaldine_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "barcaldine_regional_council/rebecca_plumb",
       "organization_id": "legislature/barcaldine_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
@@ -3633,31 +4264,19 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "barcaldine_regional_council/phillip_mitchell",
-      "organization_id": "legislature/barcaldine_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "barcaldine_regional_council/russ_glindemann",
-      "organization_id": "legislature/barcaldine_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "barcoo_shire_council/julie_groves",
+      "person_id": "barcoo_shire_council/bruce_scott",
       "organization_id": "legislature/barcoo_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "barcoo_shire_council/craig_lasker",
+      "person_id": "barcoo_shire_council/dianne_pidgeon",
       "organization_id": "legislature/barcoo_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "barcoo_shire_council/ian_groves",
+      "person_id": "barcoo_shire_council/jill_fitzgerald",
       "organization_id": "legislature/barcoo_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
@@ -3681,37 +4300,37 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "blackall-tambo_regional_council/jeremy_barron",
+      "person_id": "blackall-tambo_regional_council/graham_jarvis",
       "organization_id": "legislature/blackall-tambo_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "blackall-tambo_regional_council/megan_prow",
+      "person_id": "blackall-tambo_regional_council/lindsay_russell",
       "organization_id": "legislature/blackall-tambo_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "blackall-tambo_regional_council/neville_dolinski",
+      "person_id": "blackall-tambo_regional_council/hector_heumiller",
       "organization_id": "legislature/blackall-tambo_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "blackall-tambo_regional_council/richelle_johnson",
+      "person_id": "blackall-tambo_regional_council/pam_pullos",
       "organization_id": "legislature/blackall-tambo_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "blackall-tambo_regional_council/terry_brennan",
+      "person_id": "blackall-tambo_regional_council/ben_holdcroft",
       "organization_id": "legislature/blackall-tambo_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "blackall-tambo_regional_council/tom_johnstone",
+      "person_id": "blackall-tambo_regional_council/boyd_johnstone",
       "organization_id": "legislature/blackall-tambo_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
@@ -3729,19 +4348,13 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
+      "person_id": "boulia_shire_council/rebecka_britton",
+      "organization_id": "legislature/boulia_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
       "person_id": "boulia_shire_council/brook_mcglinchey",
-      "organization_id": "legislature/boulia_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "boulia_shire_council/geoff_norton",
-      "organization_id": "legislature/boulia_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "boulia_shire_council/kelsey_neilson",
       "organization_id": "legislature/boulia_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
@@ -3749,1776 +4362,6 @@
     {
       "person_id": "boulia_shire_council/sam_beauchamp",
       "organization_id": "legislature/boulia_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "central_highlands_regional_council/peter_maguire",
-      "organization_id": "legislature/central_highlands_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "central_highlands_regional_council/charlie_brimblecombe",
-      "organization_id": "legislature/central_highlands_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "central_highlands_regional_council/gai_sypher",
-      "organization_id": "legislature/central_highlands_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "central_highlands_regional_council/gail_godwin-smith",
-      "organization_id": "legislature/central_highlands_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "central_highlands_regional_council/gail_nixon",
-      "organization_id": "legislature/central_highlands_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "central_highlands_regional_council/kev_cracknell",
-      "organization_id": "legislature/central_highlands_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "central_highlands_regional_council/kevin_pickersgill",
-      "organization_id": "legislature/central_highlands_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "central_highlands_regional_council/paul_bell",
-      "organization_id": "legislature/central_highlands_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "central_highlands_regional_council/peter_maundrell",
-      "organization_id": "legislature/central_highlands_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "diamantina_shire_council/geoff_morton",
-      "organization_id": "legislature/diamantina_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "diamantina_shire_council/don_rayment",
-      "organization_id": "legislature/diamantina_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "diamantina_shire_council/garth_tully",
-      "organization_id": "legislature/diamantina_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "diamantina_shire_council/jody_barr",
-      "organization_id": "legislature/diamantina_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "diamantina_shire_council/stephen_cramer",
-      "organization_id": "legislature/diamantina_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "gladstone_regional_council/gail_sellers",
-      "organization_id": "legislature/gladstone_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "gladstone_regional_council/colin_chapman",
-      "organization_id": "legislature/gladstone_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "gladstone_regional_council/graham_mcdonald",
-      "organization_id": "legislature/gladstone_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "gladstone_regional_council/karen_porter",
-      "organization_id": "legislature/gladstone_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "gladstone_regional_council/matt_burnett",
-      "organization_id": "legislature/gladstone_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "gladstone_regional_council/maxine_brushe",
-      "organization_id": "legislature/gladstone_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "gladstone_regional_council/ren_lanzon",
-      "organization_id": "legislature/gladstone_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "gladstone_regional_council/rick_hansen",
-      "organization_id": "legislature/gladstone_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "gladstone_regional_council/pj_sobhanian",
-      "organization_id": "legislature/gladstone_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "isaac_regional_council/anne_baker",
-      "organization_id": "legislature/isaac_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "isaac_regional_council/barbara_stranks",
-      "organization_id": "legislature/isaac_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "isaac_regional_council/dale_appleton",
-      "organization_id": "legislature/isaac_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "isaac_regional_council/delville_(nick)_wheeler",
-      "organization_id": "legislature/isaac_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "isaac_regional_council/geoffrey_bethel",
-      "organization_id": "legislature/isaac_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "isaac_regional_council/gina_lacey",
-      "organization_id": "legislature/isaac_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "isaac_regional_council/jane_pickels",
-      "organization_id": "legislature/isaac_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "isaac_regional_council/kelly_vea_vea",
-      "organization_id": "legislature/isaac_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "isaac_regional_council/peter_freeleagus",
-      "organization_id": "legislature/isaac_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "longreach_regional_council/joe_owens",
-      "organization_id": "legislature/longreach_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "longreach_regional_council/anthony_emslie",
-      "organization_id": "legislature/longreach_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "longreach_regional_council/david_morton",
-      "organization_id": "legislature/longreach_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "longreach_regional_council/jocelyn_avery",
-      "organization_id": "legislature/longreach_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "longreach_regional_council/norma_rae_bowden",
-      "organization_id": "legislature/longreach_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "longreach_regional_council/tony_nielsen",
-      "organization_id": "legislature/longreach_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "longreach_regional_council/trevor_smith",
-      "organization_id": "legislature/longreach_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mackay_regional_council/deirdre_comerford",
-      "organization_id": "legislature/mackay_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mackay_regional_council/alison_jones",
-      "organization_id": "legislature/mackay_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mackay_regional_council/chris_bonanno",
-      "organization_id": "legislature/mackay_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mackay_regional_council/david_perkins",
-      "organization_id": "legislature/mackay_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mackay_regional_council/frank_gilbert",
-      "organization_id": "legislature/mackay_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mackay_regional_council/greg_martin",
-      "organization_id": "legislature/mackay_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mackay_regional_council/kevin_casey",
-      "organization_id": "legislature/mackay_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mackay_regional_council/laurence_bonaventura",
-      "organization_id": "legislature/mackay_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mackay_regional_council/paul_steindl",
-      "organization_id": "legislature/mackay_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mackay_regional_council/ross_walker",
-      "organization_id": "legislature/mackay_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mackay_regional_council/theresa_morgan",
-      "organization_id": "legislature/mackay_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "rockhampton_regional_council/margaret_strelow",
-      "organization_id": "legislature/rockhampton_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "rockhampton_regional_council/cherie_rutherford",
-      "organization_id": "legislature/rockhampton_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "rockhampton_regional_council/ellen_smith",
-      "organization_id": "legislature/rockhampton_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "rockhampton_regional_council/greg_belz",
-      "organization_id": "legislature/rockhampton_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "rockhampton_regional_council/neil_fisher",
-      "organization_id": "legislature/rockhampton_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "rockhampton_regional_council/rose_swadling",
-      "organization_id": "legislature/rockhampton_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "rockhampton_regional_council/stephen_schwarten",
-      "organization_id": "legislature/rockhampton_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "rockhampton_regional_council/tony_williams",
-      "organization_id": "legislature/rockhampton_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "whitsunday_regional_council/jennifer_(jenny)_whitney",
-      "organization_id": "legislature/whitsunday_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "whitsunday_regional_council/john_atkinson",
-      "organization_id": "legislature/whitsunday_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "whitsunday_regional_council/andrew_willcox",
-      "organization_id": "legislature/whitsunday_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "whitsunday_regional_council/dave_clark",
-      "organization_id": "legislature/whitsunday_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "whitsunday_regional_council/jan_clifford",
-      "organization_id": "legislature/whitsunday_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "whitsunday_regional_council/john_collins",
-      "organization_id": "legislature/whitsunday_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "whitsunday_regional_council/peter_ramage",
-      "organization_id": "legislature/whitsunday_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "winton_shire_council/butch_lenton",
-      "organization_id": "legislature/winton_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "winton_shire_council/emma_forster",
-      "organization_id": "legislature/winton_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "winton_shire_council/judy_sale",
-      "organization_id": "legislature/winton_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "winton_shire_council/lyn_fraser",
-      "organization_id": "legislature/winton_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "winton_shire_council/robyn_stephens",
-      "organization_id": "legislature/winton_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "winton_shire_council/shane_mann",
-      "organization_id": "legislature/winton_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "woorabinda_aboriginal_shire_council/terry_munns",
-      "organization_id": "legislature/woorabinda_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "woorabinda_aboriginal_shire_council/archie_williams",
-      "organization_id": "legislature/woorabinda_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "woorabinda_aboriginal_shire_council/dellas_walker",
-      "organization_id": "legislature/woorabinda_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "woorabinda_aboriginal_shire_council/pamela_adams",
-      "organization_id": "legislature/woorabinda_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "woorabinda_aboriginal_shire_council/william_gulf",
-      "organization_id": "legislature/woorabinda_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "aurukun_shire_council/dereck_walpo",
-      "organization_id": "legislature/aurukun_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "aurukun_shire_council/ada_woolla",
-      "organization_id": "legislature/aurukun_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "aurukun_shire_council/angus_kerindun",
-      "organization_id": "legislature/aurukun_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "aurukun_shire_council/edgar_kerindun",
-      "organization_id": "legislature/aurukun_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "aurukun_shire_council/vera_komeeta",
-      "organization_id": "legislature/aurukun_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "burdekin_shire_council/bill_lowis",
-      "organization_id": "legislature/burdekin_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "burdekin_shire_council/lou_loizou",
-      "organization_id": "legislature/burdekin_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "burdekin_shire_council/lyndy_mccathie",
-      "organization_id": "legislature/burdekin_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "burdekin_shire_council/pierina_dalle_cort",
-      "organization_id": "legislature/burdekin_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "burdekin_shire_council/ross_lewis",
-      "organization_id": "legislature/burdekin_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "burdekin_shire_council/ted_bawden",
-      "organization_id": "legislature/burdekin_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "burdekin_shire_council/uli_liessmann",
-      "organization_id": "legislature/burdekin_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "burke_shire_council/ernie_camp",
-      "organization_id": "legislature/burke_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "burke_shire_council/larissa_lauder",
-      "organization_id": "legislature/burke_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "burke_shire_council/paul_poole",
-      "organization_id": "legislature/burke_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "burke_shire_council/tonya_murray",
-      "organization_id": "legislature/burke_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "burke_shire_council/tracy_forshaw",
-      "organization_id": "legislature/burke_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "burke_shire_council/zachary_duff",
-      "organization_id": "legislature/burke_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "cairns_regional_council/bob_manning_oam",
-      "organization_id": "legislature/cairns_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "cairns_regional_council/gregory_fennell",
-      "organization_id": "legislature/cairns_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "cairns_regional_council/jessie_richardson",
-      "organization_id": "legislature/cairns_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "cairns_regional_council/john_schilling",
-      "organization_id": "legislature/cairns_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "cairns_regional_council/linda_cooper",
-      "organization_id": "legislature/cairns_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "cairns_regional_council/max_o'halloran",
-      "organization_id": "legislature/cairns_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "cairns_regional_council/richie_bates",
-      "organization_id": "legislature/cairns_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "cairns_regional_council/cathy_zeiger",
-      "organization_id": "legislature/cairns_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "cairns_regional_council/steve_brain",
-      "organization_id": "legislature/cairns_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "cairns_regional_council/terry_james",
-      "organization_id": "legislature/cairns_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "carpentaria_shire_council/fred_pascoe",
-      "organization_id": "legislature/carpentaria_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "carpentaria_shire_council/alan_gurney",
-      "organization_id": "legislature/carpentaria_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "carpentaria_shire_council/ashley_gallagher",
-      "organization_id": "legislature/carpentaria_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "carpentaria_shire_council/john_beard",
-      "organization_id": "legislature/carpentaria_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "carpentaria_shire_council/joyce_zahner",
-      "organization_id": "legislature/carpentaria_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "carpentaria_shire_council/merle_johnson",
-      "organization_id": "legislature/carpentaria_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "carpentaria_shire_council/duane_amos",
-      "organization_id": "legislature/carpentaria_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "cassowary_coast_regional_council/alister_pike",
-      "organization_id": "legislature/cassowary_coast_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "cassowary_coast_regional_council/bill_shannon",
-      "organization_id": "legislature/cassowary_coast_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "cassowary_coast_regional_council/bryce_mcdonald",
-      "organization_id": "legislature/cassowary_coast_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "cassowary_coast_regional_council/glenn_raleigh",
-      "organization_id": "legislature/cassowary_coast_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "cassowary_coast_regional_council/ian_rule",
-      "organization_id": "legislature/cassowary_coast_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "cassowary_coast_regional_council/kylie_farinelli",
-      "organization_id": "legislature/cassowary_coast_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "cassowary_coast_regional_council/mark_nolan",
-      "organization_id": "legislature/cassowary_coast_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "charters_towers_regional_council/franklin_beveridge",
-      "organization_id": "legislature/charters_towers_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "charters_towers_regional_council/barbara_robinson",
-      "organization_id": "legislature/charters_towers_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "charters_towers_regional_council/bernie_robertson",
-      "organization_id": "legislature/charters_towers_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "charters_towers_regional_council/brian_beveridge",
-      "organization_id": "legislature/charters_towers_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "charters_towers_regional_council/joe_cooper",
-      "organization_id": "legislature/charters_towers_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "charters_towers_regional_council/mervyn_(roma)_bailey",
-      "organization_id": "legislature/charters_towers_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "charters_towers_regional_council/wally_brewer",
-      "organization_id": "legislature/charters_towers_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "cloncurry_shire_council/andrew_daniels",
-      "organization_id": "legislature/cloncurry_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "cloncurry_shire_council/colin_ferguson",
-      "organization_id": "legislature/cloncurry_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "cloncurry_shire_council/jane_mcmillan",
-      "organization_id": "legislature/cloncurry_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "cloncurry_shire_council/keith_douglas",
-      "organization_id": "legislature/cloncurry_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "cloncurry_shire_council/robert_mcdonald",
-      "organization_id": "legislature/cloncurry_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "cook_shire_council/peter_scott",
-      "organization_id": "legislature/cook_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "cook_shire_council/alan_wilson",
-      "organization_id": "legislature/cook_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "cook_shire_council/glen_shephard",
-      "organization_id": "legislature/cook_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "cook_shire_council/kaz_price",
-      "organization_id": "legislature/cook_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "cook_shire_council/penny_johnson",
-      "organization_id": "legislature/cook_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "cook_shire_council/russell_bowman",
-      "organization_id": "legislature/cook_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "cook_shire_council/sue_clark",
-      "organization_id": "legislature/cook_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "croydon_shire_council/trevor_pickering",
-      "organization_id": "legislature/croydon_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "croydon_shire_council/kim_gaynor",
-      "organization_id": "legislature/croydon_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "croydon_shire_council/john_pickering",
-      "organization_id": "legislature/croydon_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "croydon_shire_council/michelle_martin",
-      "organization_id": "legislature/croydon_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "croydon_shire_council/peter_kennedy",
-      "organization_id": "legislature/croydon_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "doomadgee_aboriginal_shire_council/frederick_o'keefe",
-      "organization_id": "legislature/doomadgee_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "doomadgee_aboriginal_shire_council/elaine_cairns",
-      "organization_id": "legislature/doomadgee_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "doomadgee_aboriginal_shire_council/jason_ned",
-      "organization_id": "legislature/doomadgee_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "doomadgee_aboriginal_shire_council/tony_douglas",
-      "organization_id": "legislature/doomadgee_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "doomadgee_aboriginal_shire_council/vernon_ned",
-      "organization_id": "legislature/doomadgee_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "etheridge_shire_council/will_attwood",
-      "organization_id": "legislature/etheridge_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "etheridge_shire_council/ian_tincknell",
-      "organization_id": "legislature/etheridge_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "etheridge_shire_council/pauline_royes",
-      "organization_id": "legislature/etheridge_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "etheridge_shire_council/trevor_arnett",
-      "organization_id": "legislature/etheridge_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "etheridge_shire_council/warren_bethel",
-      "organization_id": "legislature/etheridge_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "flinders_shire_council/greg_jones",
-      "organization_id": "legislature/flinders_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "flinders_shire_council/authur_(bill)_bode",
-      "organization_id": "legislature/flinders_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "flinders_shire_council/barbara_geisler",
-      "organization_id": "legislature/flinders_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "flinders_shire_council/jane_charuba",
-      "organization_id": "legislature/flinders_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "flinders_shire_council/ninian_stewart-moore",
-      "organization_id": "legislature/flinders_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "flinders_shire_council/sean_o'neill",
-      "organization_id": "legislature/flinders_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "flinders_shire_council/shane_mccarthy",
-      "organization_id": "legislature/flinders_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "hinchinbrook_shire_council/mansell_(rodger)_bow",
-      "organization_id": "legislature/hinchinbrook_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "hinchinbrook_shire_council/david_carr",
-      "organization_id": "legislature/hinchinbrook_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "hinchinbrook_shire_council/lawrence_molachino",
-      "organization_id": "legislature/hinchinbrook_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "hinchinbrook_shire_council/marc_tack",
-      "organization_id": "legislature/hinchinbrook_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "hinchinbrook_shire_council/sherry_kaurila",
-      "organization_id": "legislature/hinchinbrook_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "hinchinbrook_shire_council/wallis_(wally)_skinner",
-      "organization_id": "legislature/hinchinbrook_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "hinchinbrook_shire_council/patrick_lynch",
-      "organization_id": "legislature/hinchinbrook_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "hope_vale_aboriginal_shire_council/carmen_pearson",
-      "organization_id": "legislature/hope_vale_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "hope_vale_aboriginal_shire_council/christopher_woibo",
-      "organization_id": "legislature/hope_vale_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "hope_vale_aboriginal_shire_council/dwayne_bowen",
-      "organization_id": "legislature/hope_vale_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "hope_vale_aboriginal_shire_council/greg_mclean",
-      "organization_id": "legislature/hope_vale_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "hope_vale_aboriginal_shire_council/june_pearson",
-      "organization_id": "legislature/hope_vale_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "kowanyama_aboriginal_shire_council/robert_holness",
-      "organization_id": "legislature/kowanyama_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "kowanyama_aboriginal_shire_council/teddy_bernard",
-      "organization_id": "legislature/kowanyama_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "kowanyama_aboriginal_shire_council/william_thomas",
-      "organization_id": "legislature/kowanyama_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "kowanyama_aboriginal_shire_council/michael_yam",
-      "organization_id": "legislature/kowanyama_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "lockhart_river_aboriginal_shire_council/wayne_butcher",
-      "organization_id": "legislature/lockhart_river_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "lockhart_river_aboriginal_shire_council/norman_bally",
-      "organization_id": "legislature/lockhart_river_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "lockhart_river_aboriginal_shire_council/paul_piva",
-      "organization_id": "legislature/lockhart_river_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "lockhart_river_aboriginal_shire_council/rebecca_elu",
-      "organization_id": "legislature/lockhart_river_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "lockhart_river_aboriginal_shire_council/veronica_piva",
-      "organization_id": "legislature/lockhart_river_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mapoon_aboriginal_shire_council/peter_guivarra",
-      "organization_id": "legislature/mapoon_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mapoon_aboriginal_shire_council/aileen_addo",
-      "organization_id": "legislature/mapoon_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mapoon_aboriginal_shire_council/beryl_woodley",
-      "organization_id": "legislature/mapoon_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mapoon_aboriginal_shire_council/polly_smith",
-      "organization_id": "legislature/mapoon_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mapoon_aboriginal_shire_council/ricky_guivarra",
-      "organization_id": "legislature/mapoon_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mckinlay_shire_council/belinda_murphy",
-      "organization_id": "legislature/mckinlay_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mckinlay_shire_council/anthony_batt",
-      "organization_id": "legislature/mckinlay_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mckinlay_shire_council/edwina_hick",
-      "organization_id": "legislature/mckinlay_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mckinlay_shire_council/neil_walker",
-      "organization_id": "legislature/mckinlay_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mckinlay_shire_council/philip_curr",
-      "organization_id": "legislature/mckinlay_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mornington_shire_council/bradley_wilson",
-      "organization_id": "legislature/mornington_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mornington_shire_council/bob_thompson",
-      "organization_id": "legislature/mornington_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mornington_shire_council/jimmy_wilson",
-      "organization_id": "legislature/mornington_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mornington_shire_council/robyrta_felton",
-      "organization_id": "legislature/mornington_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mornington_shire_council/sean_linden",
-      "organization_id": "legislature/mornington_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mount_isa_city_council/tony_mcgrady",
-      "organization_id": "legislature/mount_isa_city_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mount_isa_city_council/anne_seymour",
-      "organization_id": "legislature/mount_isa_city_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mount_isa_city_council/brett_peterson",
-      "organization_id": "legislature/mount_isa_city_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mount_isa_city_council/george_fortune",
-      "organization_id": "legislature/mount_isa_city_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mount_isa_city_council/jean_ferris",
-      "organization_id": "legislature/mount_isa_city_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mount_isa_city_council/joyce_mccullock",
-      "organization_id": "legislature/mount_isa_city_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mount_isa_city_council/kim_coghlan",
-      "organization_id": "legislature/mount_isa_city_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "napranum_aboriginal_shire_council/philemon_mene",
-      "organization_id": "legislature/napranum_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "napranum_aboriginal_shire_council/maryann_coconut",
-      "organization_id": "legislature/napranum_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "napranum_aboriginal_shire_council/margie_adidi",
-      "organization_id": "legislature/napranum_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "napranum_aboriginal_shire_council/rex_burke",
-      "organization_id": "legislature/napranum_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "napranum_aboriginal_shire_council/rhonda_charger",
-      "organization_id": "legislature/napranum_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "northern_peninsula_area_regional_council/bernard_charlie",
-      "organization_id": "legislature/northern_peninsula_area_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "northern_peninsula_area_regional_council/anthony_mara",
-      "organization_id": "legislature/northern_peninsula_area_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "northern_peninsula_area_regional_council/dennis_getawan",
-      "organization_id": "legislature/northern_peninsula_area_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "northern_peninsula_area_regional_council/edward_newman",
-      "organization_id": "legislature/northern_peninsula_area_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "northern_peninsula_area_regional_council/joseph_elu",
-      "organization_id": "legislature/northern_peninsula_area_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "northern_peninsula_area_regional_council/trevor_lifu",
-      "organization_id": "legislature/northern_peninsula_area_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "palm_island_aboriginal_shire_council/alfred_lacey",
-      "organization_id": "legislature/palm_island_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "palm_island_aboriginal_shire_council/edward_walsh",
-      "organization_id": "legislature/palm_island_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "palm_island_aboriginal_shire_council/frank_conway",
-      "organization_id": "legislature/palm_island_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "palm_island_aboriginal_shire_council/roy_prior",
-      "organization_id": "legislature/palm_island_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "palm_island_aboriginal_shire_council/sam_mislam",
-      "organization_id": "legislature/palm_island_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "pormpuraaw_aboriginal_shire_council/richard_tarpencha",
-      "organization_id": "legislature/pormpuraaw_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "pormpuraaw_aboriginal_shire_council/dennis_michael",
-      "organization_id": "legislature/pormpuraaw_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "pormpuraaw_aboriginal_shire_council/lucy_foote",
-      "organization_id": "legislature/pormpuraaw_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "pormpuraaw_aboriginal_shire_council/patrick_gibuma",
-      "organization_id": "legislature/pormpuraaw_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "pormpuraaw_aboriginal_shire_council/toby_barney",
-      "organization_id": "legislature/pormpuraaw_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "richmond_shire_council/john_wharton",
-      "organization_id": "legislature/richmond_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "richmond_shire_council/david_carter",
-      "organization_id": "legislature/richmond_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "richmond_shire_council/june_kuhl",
-      "organization_id": "legislature/richmond_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "richmond_shire_council/kevin_bawden",
-      "organization_id": "legislature/richmond_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "richmond_shire_council/peter_ievers",
-      "organization_id": "legislature/richmond_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "richmond_shire_council/scott_geary",
-      "organization_id": "legislature/richmond_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "richmond_shire_council/patsy-ann_fox",
-      "organization_id": "legislature/richmond_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "tablelands_regional_council/rosa_lee_long",
-      "organization_id": "legislature/tablelands_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "tablelands_regional_council/geoff_stocker",
-      "organization_id": "legislature/tablelands_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "tablelands_regional_council/marjorie_pagani",
-      "organization_id": "legislature/tablelands_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "tablelands_regional_council/peter_hodge",
-      "organization_id": "legislature/tablelands_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "tablelands_regional_council/rod_marti",
-      "organization_id": "legislature/tablelands_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "tablelands_regional_council/shaaron_linwood",
-      "organization_id": "legislature/tablelands_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "torres_shire_council/allan_ketchell",
-      "organization_id": "legislature/torres_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "torres_shire_council/john_abednego",
-      "organization_id": "legislature/torres_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "torres_shire_council/napau_pedro_stephen",
-      "organization_id": "legislature/torres_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "torres_shire_council/willie_wigness",
-      "organization_id": "legislature/torres_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "torres_shire_council/yen_loban",
-      "organization_id": "legislature/torres_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "torres_strait_island_regional_council/fred_gela",
-      "organization_id": "legislature/torres_strait_island_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "torres_strait_island_regional_council/david_bosun",
-      "organization_id": "legislature/torres_strait_island_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "torres_strait_island_regional_council/dimas_toby",
-      "organization_id": "legislature/torres_strait_island_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "torres_strait_island_regional_council/getano_lui",
-      "organization_id": "legislature/torres_strait_island_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "torres_strait_island_regional_council/horace_baira",
-      "organization_id": "legislature/torres_strait_island_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "torres_strait_island_regional_council/rocky_stephen",
-      "organization_id": "legislature/torres_strait_island_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "torres_strait_island_regional_council/jimmy_gela",
-      "organization_id": "legislature/torres_strait_island_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "torres_strait_island_regional_council/joel_gaiden",
-      "organization_id": "legislature/torres_strait_island_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "torres_strait_island_regional_council/john_toshie_kris",
-      "organization_id": "legislature/torres_strait_island_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "torres_strait_island_regional_council/keith_fell",
-      "organization_id": "legislature/torres_strait_island_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "torres_strait_island_regional_council/mario_sabatino",
-      "organization_id": "legislature/torres_strait_island_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "torres_strait_island_regional_council/phillemon_mosby",
-      "organization_id": "legislature/torres_strait_island_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "torres_strait_island_regional_council/ron_enosa",
-      "organization_id": "legislature/torres_strait_island_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "torres_strait_island_regional_council/ted_nai",
-      "organization_id": "legislature/torres_strait_island_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "torres_strait_island_regional_council/willie_lui",
-      "organization_id": "legislature/torres_strait_island_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "townsville_city_council/jenny_hill",
-      "organization_id": "legislature/townsville_city_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/team_jenny_hill"
-    },
-    {
-      "person_id": "townsville_city_council/colleen_doyle",
-      "organization_id": "legislature/townsville_city_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/team_jenny_hill"
-    },
-    {
-      "person_id": "townsville_city_council/russ_cook",
-      "organization_id": "legislature/townsville_city_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/team_jenny_hill"
-    },
-    {
-      "person_id": "townsville_city_council/verena_coombe",
-      "organization_id": "legislature/townsville_city_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/team_jenny_hill"
-    },
-    {
-      "person_id": "townsville_city_council/les_walker",
-      "organization_id": "legislature/townsville_city_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/team_jenny_hill"
-    },
-    {
-      "person_id": "townsville_city_council/kurt_rehbein",
-      "organization_id": "legislature/townsville_city_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/team_jenny_hill"
-    },
-    {
-      "person_id": "townsville_city_council/maurie_soars",
-      "organization_id": "legislature/townsville_city_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/team_jenny_hill"
-    },
-    {
-      "person_id": "townsville_city_council/mark_molachino",
-      "organization_id": "legislature/townsville_city_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/team_jenny_hill"
-    },
-    {
-      "person_id": "townsville_city_council/ann-maree_greaney",
-      "organization_id": "legislature/townsville_city_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/team_jenny_hill"
-    },
-    {
-      "person_id": "townsville_city_council/paul_jacob",
-      "organization_id": "legislature/townsville_city_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/team_jenny_hill"
-    },
-    {
-      "person_id": "townsville_city_council/margie_ryder",
-      "organization_id": "legislature/townsville_city_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/team_jenny_hill"
-    },
-    {
-      "person_id": "wujal_wujal_aboriginal_shire_council/clifford_harrigan",
-      "organization_id": "legislature/wujal_wujal_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "wujal_wujal_aboriginal_shire_council/allister_gibson",
-      "organization_id": "legislature/wujal_wujal_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "wujal_wujal_aboriginal_shire_council/natasha_duncan",
-      "organization_id": "legislature/wujal_wujal_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "wujal_wujal_aboriginal_shire_council/vincent_tayley",
-      "organization_id": "legislature/wujal_wujal_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "yarrabah_aboriginal_shire_council/errol_neal",
-      "organization_id": "legislature/yarrabah_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "yarrabah_aboriginal_shire_council/bevan_walsh",
-      "organization_id": "legislature/yarrabah_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "yarrabah_aboriginal_shire_council/henry_miller",
-      "organization_id": "legislature/yarrabah_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "yarrabah_aboriginal_shire_council/malcolm_canendo",
-      "organization_id": "legislature/yarrabah_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "yarrabah_aboriginal_shire_council/mark_wilson",
-      "organization_id": "legislature/yarrabah_aboriginal_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "douglas_shire_council/julia_leu",
-      "organization_id": "legislature/douglas_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "douglas_shire_council/david_carey",
-      "organization_id": "legislature/douglas_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "douglas_shire_council/bruce_clarke",
-      "organization_id": "legislature/douglas_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "douglas_shire_council/terry_melchert",
-      "organization_id": "legislature/douglas_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "douglas_shire_council/abigail_noli",
-      "organization_id": "legislature/douglas_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mareeba_shire_council/tom_gilmore",
-      "organization_id": "legislature/mareeba_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mareeba_shire_council/jenny_jensen",
-      "organization_id": "legislature/mareeba_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mareeba_shire_council/alan_pederson",
-      "organization_id": "legislature/mareeba_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mareeba_shire_council/edward_(nipper)_brown",
-      "organization_id": "legislature/mareeba_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mareeba_shire_council/karen_ewin",
-      "organization_id": "legislature/mareeba_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mareeba_shire_council/allan_holmes",
-      "organization_id": "legislature/mareeba_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "mareeba_shire_council/mary_graham",
-      "organization_id": "legislature/mareeba_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "balonne_shire_council/donna_stewart",
-      "organization_id": "legislature/balonne_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "balonne_shire_council/fiona_gaske",
-      "organization_id": "legislature/balonne_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "balonne_shire_council/ian_winks",
-      "organization_id": "legislature/balonne_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "balonne_shire_council/joanne_kellock",
-      "organization_id": "legislature/balonne_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "balonne_shire_council/richard_marsh",
-      "organization_id": "legislature/balonne_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "balonne_shire_council/robert_paul",
-      "organization_id": "legislature/balonne_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "balonne_shire_council/rod_avery",
-      "organization_id": "legislature/balonne_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
@@ -5536,6 +4379,18 @@
     },
     {
       "person_id": "brisbane_city_council/jarred_cassidy",
+      "organization_id": "legislature/brisbane_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "brisbane_city_council/angela_owen",
+      "organization_id": "legislature/brisbane_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "brisbane_city_council/charles_strunk",
       "organization_id": "legislature/brisbane_city_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
@@ -5577,7 +4432,7 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "brisbane_city_council/helen_abrahams",
+      "person_id": "brisbane_city_council/johnathan_sri",
       "organization_id": "legislature/brisbane_city_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
@@ -5601,7 +4456,7 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "brisbane_city_council/kim_flesser",
+      "person_id": "brisbane_city_council/adam_allan",
       "organization_id": "legislature/brisbane_city_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
@@ -5613,7 +4468,7 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "brisbane_city_council/margaret_de_wit",
+      "person_id": "brisbane_city_council/kate_richards",
       "organization_id": "legislature/brisbane_city_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
@@ -5691,13 +4546,19 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "bulloo_shire_council/bernard_brown",
+      "person_id": "bulloo_shire_council/alison_petty",
       "organization_id": "legislature/bulloo_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "bulloo_shire_council/doug_clifford",
+      "person_id": "bulloo_shire_council/donna_humphris",
+      "organization_id": "legislature/bulloo_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "bulloo_shire_council/shirley_girdler",
       "organization_id": "legislature/bulloo_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
@@ -5709,31 +4570,37 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "bulloo_shire_council/peter_degoumois",
-      "organization_id": "legislature/bulloo_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "bundaberg_regional_council/mal_forman",
+      "person_id": "bundaberg_regional_council/jack_dempsey",
       "organization_id": "legislature/bundaberg_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "bundaberg_regional_council/alan_bush",
+      "person_id": "bundaberg_regional_council/jason_bartels",
       "organization_id": "legislature/bundaberg_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "bundaberg_regional_council/anthony_ricciardi",
+      "person_id": "bundaberg_regional_council/william_(bill)_trevor",
       "organization_id": "legislature/bundaberg_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "bundaberg_regional_council/danny_rowleson",
+      "person_id": "bundaberg_regional_council/helen_blackburn",
+      "organization_id": "legislature/bundaberg_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "bundaberg_regional_council/scott_rowleson",
+      "organization_id": "legislature/bundaberg_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "bundaberg_regional_council/peter_heuser",
       "organization_id": "legislature/bundaberg_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
@@ -5757,19 +4624,7 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "bundaberg_regional_council/lynette_forgan",
-      "organization_id": "legislature/bundaberg_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
       "person_id": "bundaberg_regional_council/ross_sommerfeld",
-      "organization_id": "legislature/bundaberg_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "bundaberg_regional_council/vincent_habermann",
       "organization_id": "legislature/bundaberg_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
@@ -5781,43 +4636,625 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
+      "person_id": "burdekin_shire_council/lyn_mclaughlin",
+      "organization_id": "legislature/burdekin_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "burdekin_shire_council/john_bonanno",
+      "organization_id": "legislature/burdekin_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "burdekin_shire_council/tony_goodard",
+      "organization_id": "legislature/burdekin_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "burdekin_shire_council/sue_perry",
+      "organization_id": "legislature/burdekin_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "burdekin_shire_council/john_woods",
+      "organization_id": "legislature/burdekin_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "burdekin_shire_council/ted_bawden",
+      "organization_id": "legislature/burdekin_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "burdekin_shire_council/uli_liessmann",
+      "organization_id": "legislature/burdekin_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "burke_shire_council/ernie_camp",
+      "organization_id": "legislature/burke_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "burke_shire_council/john_clarke",
+      "organization_id": "legislature/burke_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "burke_shire_council/john_yanner",
+      "organization_id": "legislature/burke_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "burke_shire_council/paul_poole",
+      "organization_id": "legislature/burke_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "burke_shire_council/tonya_murray",
+      "organization_id": "legislature/burke_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "cairns_regional_council/bob_manning",
+      "organization_id": "legislature/cairns_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "cairns_regional_council/brett_moller",
+      "organization_id": "legislature/cairns_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "cairns_regional_council/john_schilling",
+      "organization_id": "legislature/cairns_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "cairns_regional_council/cathy_zeiger",
+      "organization_id": "legislature/cairns_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "cairns_regional_council/terry_james",
+      "organization_id": "legislature/cairns_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "cairns_regional_council/richie_bates",
+      "organization_id": "legislature/cairns_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "cairns_regional_council/linda_cooper",
+      "organization_id": "legislature/cairns_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "cairns_regional_council/max_o'halloran",
+      "organization_id": "legislature/cairns_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "cairns_regional_council/jessie_richardson",
+      "organization_id": "legislature/cairns_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "cairns_regional_council/brett_olds",
+      "organization_id": "legislature/cairns_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "carpentaria_shire_council/lyall_(jack)_bawden",
+      "organization_id": "legislature/carpentaria_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "carpentaria_shire_council/andrew_murphy",
+      "organization_id": "legislature/carpentaria_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "carpentaria_shire_council/bradley_hawkins",
+      "organization_id": "legislature/carpentaria_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "carpentaria_shire_council/peter_wells",
+      "organization_id": "legislature/carpentaria_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "carpentaria_shire_council/james_(craig)_young",
+      "organization_id": "legislature/carpentaria_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "carpentaria_shire_council/ashley_gallagher",
+      "organization_id": "legislature/carpentaria_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "carpentaria_shire_council/john_beard",
+      "organization_id": "legislature/carpentaria_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "cassowary_coast_regional_council/john_kremastos",
+      "organization_id": "legislature/cassowary_coast_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "cassowary_coast_regional_council/rick_taylor",
+      "organization_id": "legislature/cassowary_coast_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "cassowary_coast_regional_council/wayne_kimberley",
+      "organization_id": "legislature/cassowary_coast_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "cassowary_coast_regional_council/jeffrey_baines",
+      "organization_id": "legislature/cassowary_coast_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "cassowary_coast_regional_council/ben_heath",
+      "organization_id": "legislature/cassowary_coast_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "cassowary_coast_regional_council/glenn_raleigh",
+      "organization_id": "legislature/cassowary_coast_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "cassowary_coast_regional_council/mark_nolan",
+      "organization_id": "legislature/cassowary_coast_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "central_highlands_regional_council/kerry_hayes",
+      "organization_id": "legislature/central_highlands_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "central_highlands_regional_council/megan_daniels",
+      "organization_id": "legislature/central_highlands_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "central_highlands_regional_council/david_lacey",
+      "organization_id": "legislature/central_highlands_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "central_highlands_regional_council/alan_mcindoe",
+      "organization_id": "legislature/central_highlands_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "central_highlands_regional_council/christine_rolfe",
+      "organization_id": "legislature/central_highlands_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "central_highlands_regional_council/charlie_brimblecombe",
+      "organization_id": "legislature/central_highlands_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "central_highlands_regional_council/gail_godwin-smith",
+      "organization_id": "legislature/central_highlands_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "central_highlands_regional_council/gail_nixon",
+      "organization_id": "legislature/central_highlands_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "central_highlands_regional_council/paul_bell",
+      "organization_id": "legislature/central_highlands_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "charters_towers_regional_council/liz_schmidt",
+      "organization_id": "legislature/charters_towers_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "charters_towers_regional_council/alan_barr",
+      "organization_id": "legislature/charters_towers_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "charters_towers_regional_council/graham_lohmann",
+      "organization_id": "legislature/charters_towers_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "charters_towers_regional_council/brett_maff",
+      "organization_id": "legislature/charters_towers_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "charters_towers_regional_council/mike_power",
+      "organization_id": "legislature/charters_towers_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "charters_towers_regional_council/sonia_bennetto",
+      "organization_id": "legislature/charters_towers_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "charters_towers_regional_council/mervyn_(roma)_bailey",
+      "organization_id": "legislature/charters_towers_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
       "person_id": "cherbourg_aboriginal_shire_council/kenny_bone",
       "organization_id": "legislature/cherbourg_aboriginal_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "cherbourg_aboriginal_shire_council/christine_stewart",
+      "person_id": "cherbourg_aboriginal_shire_council/alana_purcell",
       "organization_id": "legislature/cherbourg_aboriginal_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "cherbourg_aboriginal_shire_council/gordon_wragge",
+      "person_id": "cherbourg_aboriginal_shire_council/james_saltner",
       "organization_id": "legislature/cherbourg_aboriginal_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "cherbourg_aboriginal_shire_council/rory_boney",
+      "person_id": "cherbourg_aboriginal_shire_council/elvie_sandow",
       "organization_id": "legislature/cherbourg_aboriginal_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "cherbourg_aboriginal_shire_council/arnold_murray",
+      "person_id": "cherbourg_aboriginal_shire_council/tom_langton",
       "organization_id": "legislature/cherbourg_aboriginal_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "fraser_coast_regional_council/gerard_o'connell",
-      "organization_id": "legislature/fraser_coast_regional_council",
+      "person_id": "cloncurry_shire_council/gregory_campbell",
+      "organization_id": "legislature/cloncurry_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "cloncurry_shire_council/damien_mcgee",
+      "organization_id": "legislature/cloncurry_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "cloncurry_shire_council/brad_rix",
+      "organization_id": "legislature/cloncurry_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "cloncurry_shire_council/dane_swalling",
+      "organization_id": "legislature/cloncurry_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "cook_shire_council/peter_scott",
+      "organization_id": "legislature/cook_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "cook_shire_council/john_dessmann",
+      "organization_id": "legislature/cook_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "cook_shire_council/john_giese",
+      "organization_id": "legislature/cook_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "cook_shire_council/larissa_hale",
+      "organization_id": "legislature/cook_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "cook_shire_council/robyn_holmes",
+      "organization_id": "legislature/cook_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "cook_shire_council/alan_wilson",
+      "organization_id": "legislature/cook_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "cook_shire_council/kaz_price",
+      "organization_id": "legislature/cook_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "croydon_shire_council/trevor_pickering",
+      "organization_id": "legislature/croydon_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "croydon_shire_council/kim_gaynor",
+      "organization_id": "legislature/croydon_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "croydon_shire_council/wayne_bing_chew",
+      "organization_id": "legislature/croydon_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "croydon_shire_council/jim_gilmartin",
+      "organization_id": "legislature/croydon_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "croydon_shire_council/jeffrey_norman",
+      "organization_id": "legislature/croydon_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "diamantina_shire_council/geoff_morton",
+      "organization_id": "legislature/diamantina_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "diamantina_shire_council/doug_cooms",
+      "organization_id": "legislature/diamantina_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "diamantina_shire_council/bev_maunsell",
+      "organization_id": "legislature/diamantina_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "diamantina_shire_council/don_rayment",
+      "organization_id": "legislature/diamantina_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "diamantina_shire_council/stephen_cramer",
+      "organization_id": "legislature/diamantina_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "doomadgee_aboriginal_shire_council/edric_walden",
+      "organization_id": "legislature/doomadgee_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "doomadgee_aboriginal_shire_council/tony_chong",
+      "organization_id": "legislature/doomadgee_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "doomadgee_aboriginal_shire_council/dean_jupiter",
+      "organization_id": "legislature/doomadgee_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "doomadgee_aboriginal_shire_council/scharrayne_foster",
+      "organization_id": "legislature/doomadgee_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "doomadgee_aboriginal_shire_council/jason_ned",
+      "organization_id": "legislature/doomadgee_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "douglas_shire_council/michael_kerr",
+      "organization_id": "legislature/douglas_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "douglas_shire_council/roy_zammataro",
+      "organization_id": "legislature/douglas_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "douglas_shire_council/julia_leu",
+      "organization_id": "legislature/douglas_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "douglas_shire_council/david_carey",
+      "organization_id": "legislature/douglas_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "douglas_shire_council/abigail_noli",
+      "organization_id": "legislature/douglas_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "etheridge_shire_council/warren_devlin",
+      "organization_id": "legislature/etheridge_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "etheridge_shire_council/troy_barnes",
+      "organization_id": "legislature/etheridge_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "etheridge_shire_council/tony_gallagher",
+      "organization_id": "legislature/etheridge_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "etheridge_shire_council/warren_bethel",
+      "organization_id": "legislature/etheridge_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "etheridge_shire_council/will_attwood",
+      "organization_id": "legislature/etheridge_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "flinders_shire_council/jane_mcnamara",
+      "organization_id": "legislature/flinders_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "flinders_shire_council/kelly_carter",
+      "organization_id": "legislature/flinders_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "flinders_shire_council/graham_sealy",
+      "organization_id": "legislature/flinders_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "flinders_shire_council/kate_downie",
+      "organization_id": "legislature/flinders_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "flinders_shire_council/authur_(bill)_bode",
+      "organization_id": "legislature/flinders_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "flinders_shire_council/sean_o'neill",
+      "organization_id": "legislature/flinders_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
       "person_id": "fraser_coast_regional_council/chris_loft",
+      "organization_id": "legislature/fraser_coast_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "fraser_coast_regional_council/anne_maddern",
+      "organization_id": "legislature/fraser_coast_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "fraser_coast_regional_council/paul_truscott",
+      "organization_id": "legislature/fraser_coast_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "fraser_coast_regional_council/david_lewis",
+      "organization_id": "legislature/fraser_coast_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "fraser_coast_regional_council/denis_chapman",
       "organization_id": "legislature/fraser_coast_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
@@ -5847,18 +5284,6 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "fraser_coast_regional_council/phil_truscott",
-      "organization_id": "legislature/fraser_coast_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "fraser_coast_regional_council/robert_garland",
-      "organization_id": "legislature/fraser_coast_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
       "person_id": "fraser_coast_regional_council/rolf_light",
       "organization_id": "legislature/fraser_coast_regional_council",
       "role": "councillor",
@@ -5871,79 +5296,61 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "fraser_coast_regional_council/trevor_mcdonald",
-      "organization_id": "legislature/fraser_coast_regional_council",
+      "person_id": "gladstone_regional_council/matt_burnett",
+      "organization_id": "legislature/gladstone_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "gold_coast_city_council/tom_tate",
-      "organization_id": "legislature/gold_coast_city_council",
+      "person_id": "gladstone_regional_council/cindi_bush",
+      "organization_id": "legislature/gladstone_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "gold_coast_city_council/bob_la_castra",
-      "organization_id": "legislature/gold_coast_city_council",
+      "person_id": "gladstone_regional_council/glen_churchill",
+      "organization_id": "legislature/gladstone_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "gold_coast_city_council/cameron_caldwell",
-      "organization_id": "legislature/gold_coast_city_council",
+      "person_id": "gladstone_regional_council/kahn_goodluck",
+      "organization_id": "legislature/gladstone_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "gold_coast_city_council/chris_robbins",
-      "organization_id": "legislature/gold_coast_city_council",
+      "person_id": "gladstone_regional_council/peter_masters",
+      "organization_id": "legislature/gladstone_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "gold_coast_city_council/daphne_mcdonald",
-      "organization_id": "legislature/gold_coast_city_council",
+      "person_id": "gladstone_regional_council/desley_o'grady",
+      "organization_id": "legislature/gladstone_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "gold_coast_city_council/dawn_crichlow",
-      "organization_id": "legislature/gold_coast_city_council",
+      "person_id": "gladstone_regional_council/chris_(ct)_trevor",
+      "organization_id": "legislature/gladstone_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "gladstone_regional_council/rick_hansen",
+      "organization_id": "legislature/gladstone_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "gladstone_regional_council/pj_sobhanian",
+      "organization_id": "legislature/gladstone_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
       "person_id": "gold_coast_city_council/donna_gates",
-      "organization_id": "legislature/gold_coast_city_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "gold_coast_city_council/glenn_tozer",
-      "organization_id": "legislature/gold_coast_city_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "gold_coast_city_council/greg_betts",
-      "organization_id": "legislature/gold_coast_city_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "gold_coast_city_council/jan_grew",
-      "organization_id": "legislature/gold_coast_city_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "gold_coast_city_council/lex_bell",
-      "organization_id": "legislature/gold_coast_city_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "gold_coast_city_council/margaret_grummitt",
       "organization_id": "legislature/gold_coast_city_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
@@ -5955,7 +5362,25 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "gold_coast_city_council/tracey_gilmore",
+      "person_id": "gold_coast_city_council/herman_vorster",
+      "organization_id": "legislature/gold_coast_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "gold_coast_city_council/pauline_young",
+      "organization_id": "legislature/gold_coast_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "gold_coast_city_council/daphne_mcdonald",
+      "organization_id": "legislature/gold_coast_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "gold_coast_city_council/gail_o'neill",
       "organization_id": "legislature/gold_coast_city_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
@@ -5967,25 +5392,73 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
+      "person_id": "gold_coast_city_council/cameron_caldwell",
+      "organization_id": "legislature/gold_coast_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "gold_coast_city_council/kristyn_boulton",
+      "organization_id": "legislature/gold_coast_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "gold_coast_city_council/peter_young",
+      "organization_id": "legislature/gold_coast_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "gold_coast_city_council/gary_baildon",
+      "organization_id": "legislature/gold_coast_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "gold_coast_city_council/bob_la_castra",
+      "organization_id": "legislature/gold_coast_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "gold_coast_city_council/glenn_tozer",
+      "organization_id": "legislature/gold_coast_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "gold_coast_city_council/dawn_crichlow",
+      "organization_id": "legislature/gold_coast_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "gold_coast_city_council/tom_tate",
+      "organization_id": "legislature/gold_coast_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
       "person_id": "goondiwindi_regional_council/graeme_scheu",
       "organization_id": "legislature/goondiwindi_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "goondiwindi_regional_council/david_mcmahon",
+      "person_id": "goondiwindi_regional_council/lachlan_brennan",
+      "organization_id": "legislature/goondiwindi_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "goondiwindi_regional_council/david_turner",
       "organization_id": "legislature/goondiwindi_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
       "person_id": "goondiwindi_regional_council/joan_white",
-      "organization_id": "legislature/goondiwindi_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "goondiwindi_regional_council/lori_mackay",
       "organization_id": "legislature/goondiwindi_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
@@ -6009,7 +5482,7 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "gympie_regional_council/ray_currie",
+      "person_id": "gympie_regional_council/mick_curran",
       "organization_id": "legislature/gympie_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
@@ -6021,19 +5494,37 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "gympie_regional_council/ian_petersen",
+      "person_id": "gympie_regional_council/glen_hartwig",
       "organization_id": "legislature/gympie_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "gympie_regional_council/julie_walker",
+      "person_id": "gympie_regional_council/mal_gear",
       "organization_id": "legislature/gympie_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "gympie_regional_council/larry_friske",
+      "person_id": "gympie_regional_council/daryl_dodt",
+      "organization_id": "legislature/gympie_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "gympie_regional_council/dan_stewart",
+      "organization_id": "legislature/gympie_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "gympie_regional_council/hilary_smerdon",
+      "organization_id": "legislature/gympie_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "gympie_regional_council/james_cochrane",
       "organization_id": "legislature/gympie_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
@@ -6045,20 +5536,74 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "gympie_regional_council/mick_curran",
-      "organization_id": "legislature/gympie_regional_council",
+      "person_id": "hinchinbrook_shire_council/ramon_jayo",
+      "organization_id": "legislature/hinchinbrook_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "gympie_regional_council/rae_gate",
-      "organization_id": "legislature/gympie_regional_council",
+      "person_id": "hinchinbrook_shire_council/maria_bosworth",
+      "organization_id": "legislature/hinchinbrook_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "gympie_regional_council/wayne_sachs",
-      "organization_id": "legislature/gympie_regional_council",
+      "person_id": "hinchinbrook_shire_council/mary_brown",
+      "organization_id": "legislature/hinchinbrook_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "hinchinbrook_shire_council/andrew_lancini",
+      "organization_id": "legislature/hinchinbrook_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "hinchinbrook_shire_council/kate_milton",
+      "organization_id": "legislature/hinchinbrook_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "hinchinbrook_shire_council/marc_tack",
+      "organization_id": "legislature/hinchinbrook_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "hinchinbrook_shire_council/wallis_(wally)_skinner",
+      "organization_id": "legislature/hinchinbrook_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "hope_vale_aboriginal_shire_council/barry_bowen",
+      "organization_id": "legislature/hope_vale_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "hope_vale_aboriginal_shire_council/selina_bowen",
+      "organization_id": "legislature/hope_vale_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "hope_vale_aboriginal_shire_council/bruce_gibson",
+      "organization_id": "legislature/hope_vale_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "hope_vale_aboriginal_shire_council/greg_mclean",
+      "organization_id": "legislature/hope_vale_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "hope_vale_aboriginal_shire_council/june_pearson",
+      "organization_id": "legislature/hope_vale_aboriginal_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
@@ -6069,13 +5614,25 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "ipswich_city_council/andrew_antoniolli",
+      "person_id": "ipswich_city_council/kerry_silver",
       "organization_id": "legislature/ipswich_city_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "ipswich_city_council/kerry_silver",
+      "person_id": "ipswich_city_council/kylie_stoneman",
+      "organization_id": "legislature/ipswich_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "ipswich_city_council/wayne_wendt",
+      "organization_id": "legislature/ipswich_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "ipswich_city_council/andrew_antoniolli",
       "organization_id": "legislature/ipswich_city_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
@@ -6105,12 +5662,6 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "ipswich_city_council/kylie_stoneman",
-      "organization_id": "legislature/ipswich_city_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
       "person_id": "ipswich_city_council/paul_tully",
       "organization_id": "legislature/ipswich_city_council",
       "role": "councillor",
@@ -6123,8 +5674,158 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "ipswich_city_council/wayne_wendt",
-      "organization_id": "legislature/ipswich_city_council",
+      "person_id": "isaac_regional_council/anne_baker",
+      "organization_id": "legislature/isaac_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "isaac_regional_council/lynette_(lyn)_jones",
+      "organization_id": "legislature/isaac_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "isaac_regional_council/dale_appleton",
+      "organization_id": "legislature/isaac_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "isaac_regional_council/delville_(nick)_wheeler",
+      "organization_id": "legislature/isaac_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "isaac_regional_council/geoffrey_bethel",
+      "organization_id": "legislature/isaac_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "isaac_regional_council/gina_lacey",
+      "organization_id": "legislature/isaac_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "isaac_regional_council/jane_pickels",
+      "organization_id": "legislature/isaac_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "isaac_regional_council/kelly_vea_vea",
+      "organization_id": "legislature/isaac_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "isaac_regional_council/peter_freeleagus",
+      "organization_id": "legislature/isaac_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "kowanyama_aboriginal_shire_council/michael_yam",
+      "organization_id": "legislature/kowanyama_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "kowanyama_aboriginal_shire_council/territa_dick",
+      "organization_id": "legislature/kowanyama_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "kowanyama_aboriginal_shire_council/john_fry",
+      "organization_id": "legislature/kowanyama_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "kowanyama_aboriginal_shire_council/colin_lawrence",
+      "organization_id": "legislature/kowanyama_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "kowanyama_aboriginal_shire_council/wendy_wust",
+      "organization_id": "legislature/kowanyama_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "livingstone_shire_council/bill_ludwig",
+      "organization_id": "legislature/livingstone_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "livingstone_shire_council/adam_belot",
+      "organization_id": "legislature/livingstone_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "livingstone_shire_council/glenda_mather",
+      "organization_id": "legislature/livingstone_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "livingstone_shire_council/graham_scott",
+      "organization_id": "legislature/livingstone_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "livingstone_shire_council/jan_kelly",
+      "organization_id": "legislature/livingstone_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "livingstone_shire_council/nigel_hutton",
+      "organization_id": "legislature/livingstone_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "livingstone_shire_council/tom_wyatt",
+      "organization_id": "legislature/livingstone_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "lockhart_river_aboriginal_shire_council/wayne_butcher",
+      "organization_id": "legislature/lockhart_river_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "lockhart_river_aboriginal_shire_council/marshall_symonds",
+      "organization_id": "legislature/lockhart_river_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "lockhart_river_aboriginal_shire_council/dorothy_hobson",
+      "organization_id": "legislature/lockhart_river_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "lockhart_river_aboriginal_shire_council/norman_bally",
+      "organization_id": "legislature/lockhart_river_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "lockhart_river_aboriginal_shire_council/paul_piva",
+      "organization_id": "legislature/lockhart_river_aboriginal_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
@@ -6135,7 +5836,19 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "lockyer_valley_regional_council/derek_pingel",
+      "person_id": "lockyer_valley_regional_council/michael_hagan",
+      "organization_id": "legislature/lockyer_valley_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "lockyer_valley_regional_council/jason_cook",
+      "organization_id": "legislature/lockyer_valley_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "lockyer_valley_regional_council/chris_wilson",
       "organization_id": "legislature/lockyer_valley_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
@@ -6159,19 +5872,25 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "lockyer_valley_regional_council/peter_friend",
-      "organization_id": "legislature/lockyer_valley_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "lockyer_valley_regional_council/tanya_milligan",
-      "organization_id": "legislature/lockyer_valley_regional_council",
+      "person_id": "logan_city_council/luke_smith",
+      "organization_id": "legislature/logan_city_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
       "person_id": "logan_city_council/laurie_koranski",
+      "organization_id": "legislature/logan_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "logan_city_council/jon_raven",
+      "organization_id": "legislature/logan_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "logan_city_council/stacey_mcintosh",
       "organization_id": "legislature/logan_city_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
@@ -6184,18 +5903,6 @@
     },
     {
       "person_id": "logan_city_council/darren_power",
-      "organization_id": "legislature/logan_city_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "logan_city_council/jon_raven",
-      "organization_id": "legislature/logan_city_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "logan_city_council/graham_able",
       "organization_id": "legislature/logan_city_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
@@ -6214,12 +5921,6 @@
     },
     {
       "person_id": "logan_city_council/lisa_bradley",
-      "organization_id": "legislature/logan_city_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "logan_city_council/luke_smith",
       "organization_id": "legislature/logan_city_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
@@ -6249,7 +5950,169 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "maranoa_regional_council/robert_loughnan",
+      "person_id": "longreach_regional_council/joe_owens",
+      "organization_id": "legislature/longreach_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "longreach_regional_council/leonie_nunn",
+      "organization_id": "legislature/longreach_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "longreach_regional_council/trevor_harris",
+      "organization_id": "legislature/longreach_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "longreach_regional_council/tony_martin",
+      "organization_id": "legislature/longreach_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "longreach_regional_council/anthony_rayner",
+      "organization_id": "legislature/longreach_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "longreach_regional_council/anthony_emslie",
+      "organization_id": "legislature/longreach_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "longreach_regional_council/trevor_smith",
+      "organization_id": "legislature/longreach_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "mackay_regional_council/greg_williamson",
+      "organization_id": "legislature/mackay_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "mackay_regional_council/amanda_camm",
+      "organization_id": "legislature/mackay_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "mackay_regional_council/kevin_casey",
+      "organization_id": "legislature/mackay_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "mackay_regional_council/justin_englert",
+      "organization_id": "legislature/mackay_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "mackay_regional_council/fran_fordham",
+      "organization_id": "legislature/mackay_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "mackay_regional_council/ross_gee",
+      "organization_id": "legislature/mackay_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "mackay_regional_council/karen_may",
+      "organization_id": "legislature/mackay_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "mackay_regional_council/ayril_paton",
+      "organization_id": "legislature/mackay_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "mackay_regional_council/martin_bella",
+      "organization_id": "legislature/mackay_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "mackay_regional_council/laurence_bonaventura",
+      "organization_id": "legislature/mackay_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "mackay_regional_council/ross_walker",
+      "organization_id": "legislature/mackay_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "mapoon_aboriginal_shire_council/aileen_addo",
+      "organization_id": "legislature/mapoon_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "mapoon_aboriginal_shire_council/margaret_mara",
+      "organization_id": "legislature/mapoon_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "mapoon_aboriginal_shire_council/brendan_brown",
+      "organization_id": "legislature/mapoon_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "mapoon_aboriginal_shire_council/peter_guivarra",
+      "organization_id": "legislature/mapoon_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "mapoon_aboriginal_shire_council/pauline_smith",
+      "organization_id": "legislature/mapoon_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "maranoa_regional_council/tyson_golder",
+      "organization_id": "legislature/maranoa_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "maranoa_regional_council/robyn_bryant",
+      "organization_id": "legislature/maranoa_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "maranoa_regional_council/geoff_mcmullen",
+      "organization_id": "legislature/maranoa_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "maranoa_regional_council/janelle_stanford",
+      "organization_id": "legislature/maranoa_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "maranoa_regional_council/n_(puddy)_chandler",
       "organization_id": "legislature/maranoa_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
@@ -6273,32 +6136,80 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "maranoa_regional_council/joy_denton",
-      "organization_id": "legislature/maranoa_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
       "person_id": "maranoa_regional_council/peter_flynn",
       "organization_id": "legislature/maranoa_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "maranoa_regional_council/ree_price",
-      "organization_id": "legislature/maranoa_regional_council",
+      "person_id": "mareeba_shire_council/tom_gilmore",
+      "organization_id": "legislature/mareeba_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "maranoa_regional_council/scott_wason",
-      "organization_id": "legislature/maranoa_regional_council",
+      "person_id": "mareeba_shire_council/kevin_davies",
+      "organization_id": "legislature/mareeba_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "maranoa_regional_council/wendy_newman",
-      "organization_id": "legislature/maranoa_regional_council",
+      "person_id": "mareeba_shire_council/angela_toppin",
+      "organization_id": "legislature/mareeba_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "mareeba_shire_council/lenore_wyatt",
+      "organization_id": "legislature/mareeba_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "mareeba_shire_council/alan_pedersen",
+      "organization_id": "legislature/mareeba_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "mareeba_shire_council/edward_(nipper)_brown",
+      "organization_id": "legislature/mareeba_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "mareeba_shire_council/mary_graham",
+      "organization_id": "legislature/mareeba_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "mckinlay_shire_council/belinda_murphy",
+      "organization_id": "legislature/mckinlay_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "mckinlay_shire_council/shauna_royes",
+      "organization_id": "legislature/mckinlay_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "mckinlay_shire_council/janene_fegan",
+      "organization_id": "legislature/mckinlay_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "mckinlay_shire_council/neil_walker",
+      "organization_id": "legislature/mckinlay_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "mckinlay_shire_council/philip_curr",
+      "organization_id": "legislature/mckinlay_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
@@ -6315,49 +6226,13 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "moreton_bay_regional_council/peter_flannery",
-      "organization_id": "legislature/moreton_bay_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
       "person_id": "moreton_bay_regional_council/adam_hain",
       "organization_id": "legislature/moreton_bay_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "moreton_bay_regional_council/julie_greer",
-      "organization_id": "legislature/moreton_bay_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "moreton_bay_regional_council/james_houghton",
-      "organization_id": "legislature/moreton_bay_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "moreton_bay_regional_council/koliana_winchester",
-      "organization_id": "legislature/moreton_bay_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
       "person_id": "moreton_bay_regional_council/denise_sims",
-      "organization_id": "legislature/moreton_bay_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "moreton_bay_regional_council/mick_gillam",
-      "organization_id": "legislature/moreton_bay_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "moreton_bay_regional_council/mike_charlton",
       "organization_id": "legislature/moreton_bay_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
@@ -6381,8 +6256,110 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "murweh_shire_council/denis_cook",
-      "organization_id": "legislature/murweh_shire_council",
+      "person_id": "moreton_bay_regional_council/james_houghton",
+      "organization_id": "legislature/moreton_bay_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "moreton_bay_regional_council/julie_greer",
+      "organization_id": "legislature/moreton_bay_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "moreton_bay_regional_council/koliana_winchester",
+      "organization_id": "legislature/moreton_bay_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "moreton_bay_regional_council/mick_gillam",
+      "organization_id": "legislature/moreton_bay_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "moreton_bay_regional_council/mike_charlton",
+      "organization_id": "legislature/moreton_bay_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "moreton_bay_regional_council/peter_flannery",
+      "organization_id": "legislature/moreton_bay_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "mornington_shire_council/bradley_wilson",
+      "organization_id": "legislature/mornington_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "mornington_shire_council/sarah_isaacs",
+      "organization_id": "legislature/mornington_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "mornington_shire_council/jane_ah_kit",
+      "organization_id": "legislature/mornington_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "mornington_shire_council/clair_farrell",
+      "organization_id": "legislature/mornington_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "mornington_shire_council/bob_thompson",
+      "organization_id": "legislature/mornington_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "mount_isa_city_council/joyce_mcculloch",
+      "organization_id": "legislature/mount_isa_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "mount_isa_city_council/peta_macrae",
+      "organization_id": "legislature/mount_isa_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "mount_isa_city_council/phil_barwick",
+      "organization_id": "legislature/mount_isa_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "mount_isa_city_council/paul_stretton",
+      "organization_id": "legislature/mount_isa_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "mount_isa_city_council/mick_tully",
+      "organization_id": "legislature/mount_isa_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "mount_isa_city_council/george_fortune",
+      "organization_id": "legislature/mount_isa_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "mount_isa_city_council/jean_ferris",
+      "organization_id": "legislature/mount_isa_city_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
@@ -6393,7 +6370,13 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "murweh_shire_council/cecil_russell",
+      "person_id": "murweh_shire_council/shaun_(zoro)_radnedge",
+      "organization_id": "legislature/murweh_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "murweh_shire_council/lyn_capewell",
       "organization_id": "legislature/murweh_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
@@ -6411,7 +6394,109 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
+      "person_id": "napranum_aboriginal_shire_council/rex_burke",
+      "organization_id": "legislature/napranum_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "napranum_aboriginal_shire_council/ethel_bosuen",
+      "organization_id": "legislature/napranum_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "napranum_aboriginal_shire_council/sonia_schuh",
+      "organization_id": "legislature/napranum_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "napranum_aboriginal_shire_council/fiona_wirrer-george",
+      "organization_id": "legislature/napranum_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "napranum_aboriginal_shire_council/rhonda_charger",
+      "organization_id": "legislature/napranum_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "noosa_shire_council/tony_wellington",
+      "organization_id": "legislature/noosa_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "noosa_shire_council/jess_glasgow",
+      "organization_id": "legislature/noosa_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "noosa_shire_council/ingrid_jackson",
+      "organization_id": "legislature/noosa_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "noosa_shire_council/brian_stockwell",
+      "organization_id": "legislature/noosa_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "noosa_shire_council/bob_abbott",
+      "organization_id": "legislature/noosa_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "noosa_shire_council/frank_pardon",
+      "organization_id": "legislature/noosa_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "noosa_shire_council/frank_wilkie",
+      "organization_id": "legislature/noosa_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "noosa_shire_council/joe_jurisevic",
+      "organization_id": "legislature/noosa_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "noosa_shire_council/sandy_bolton",
+      "organization_id": "legislature/noosa_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
       "person_id": "north_burnett_regional_council/don_waugh",
+      "organization_id": "legislature/north_burnett_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "north_burnett_regional_council/peter_webster",
+      "organization_id": "legislature/north_burnett_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "north_burnett_regional_council/john_zahl",
+      "organization_id": "legislature/north_burnett_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "north_burnett_regional_council/robert_radel",
       "organization_id": "legislature/north_burnett_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
@@ -6423,25 +6508,7 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "north_burnett_regional_council/joanne_dowling",
-      "organization_id": "legislature/north_burnett_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
       "person_id": "north_burnett_regional_council/john_bowen",
-      "organization_id": "legislature/north_burnett_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "north_burnett_regional_council/kevin_(lofty)_wendt",
-      "organization_id": "legislature/north_burnett_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "north_burnett_regional_council/paul_francis",
       "organization_id": "legislature/north_burnett_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
@@ -6453,13 +6520,79 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
+      "person_id": "northern_peninsula_area_regional_council/edward_newman",
+      "organization_id": "legislature/northern_peninsula_area_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "northern_peninsula_area_regional_council/gina_nona",
+      "organization_id": "legislature/northern_peninsula_area_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "northern_peninsula_area_regional_council/peter_lui",
+      "organization_id": "legislature/northern_peninsula_area_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "northern_peninsula_area_regional_council/cassandra_adidi",
+      "organization_id": "legislature/northern_peninsula_area_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "northern_peninsula_area_regional_council/michael_bond",
+      "organization_id": "legislature/northern_peninsula_area_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "northern_peninsula_area_regional_council/joseph_elu",
+      "organization_id": "legislature/northern_peninsula_area_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "palm_island_aboriginal_shire_council/alfred_lacey",
+      "organization_id": "legislature/palm_island_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "palm_island_aboriginal_shire_council/robert_castors",
+      "organization_id": "legislature/palm_island_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "palm_island_aboriginal_shire_council/deniece_geia",
+      "organization_id": "legislature/palm_island_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "palm_island_aboriginal_shire_council/edward_walsh",
+      "organization_id": "legislature/palm_island_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "palm_island_aboriginal_shire_council/roy_prior",
+      "organization_id": "legislature/palm_island_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
       "person_id": "paroo_shire_council/lindsay_godfrey",
       "organization_id": "legislature/paroo_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "paroo_shire_council/david_land",
+      "person_id": "paroo_shire_council/joann_woodcroft",
       "organization_id": "legislature/paroo_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
@@ -6477,13 +6610,61 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "paroo_shire_council/richard_brain",
+      "person_id": "paroo_shire_council/rick_brain",
       "organization_id": "legislature/paroo_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
+      "person_id": "pormpuraaw_aboriginal_shire_council/",
+      "organization_id": "legislature/pormpuraaw_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "pormpuraaw_aboriginal_shire_council/keith_barney",
+      "organization_id": "legislature/pormpuraaw_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "pormpuraaw_aboriginal_shire_council/george_simeon_conrad",
+      "organization_id": "legislature/pormpuraaw_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "pormpuraaw_aboriginal_shire_council/bert_edwards",
+      "organization_id": "legislature/pormpuraaw_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "pormpuraaw_aboriginal_shire_council/tim_koo-aga",
+      "organization_id": "legislature/pormpuraaw_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
       "person_id": "quilpie_shire_council/stuart_mackenzie",
+      "organization_id": "legislature/quilpie_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "quilpie_shire_council/robert_hall",
+      "organization_id": "legislature/quilpie_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "quilpie_shire_council/roger_volz",
+      "organization_id": "legislature/quilpie_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "quilpie_shire_council/bruce_paulsen",
       "organization_id": "legislature/quilpie_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
@@ -6495,49 +6676,31 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "quilpie_shire_council/milan_milosevic",
-      "organization_id": "legislature/quilpie_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "quilpie_shire_council/stewart_sargent",
-      "organization_id": "legislature/quilpie_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "quilpie_shire_council/tony_lilburne",
-      "organization_id": "legislature/quilpie_shire_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
       "person_id": "redland_city_council/karen_williams",
       "organization_id": "legislature/redland_city_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "redland_city_council/alan_beard",
+      "person_id": "redland_city_council/peter_mitchell",
       "organization_id": "legislature/redland_city_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "redland_city_council/craig_ogilvie",
+      "person_id": "redland_city_council/paul_golle",
+      "organization_id": "legislature/redland_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "redland_city_council/tracey_huges",
       "organization_id": "legislature/redland_city_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
       "person_id": "redland_city_council/julie_talty",
-      "organization_id": "legislature/redland_city_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "redland_city_council/kim-maree_hardman",
       "organization_id": "legislature/redland_city_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
@@ -6579,7 +6742,97 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
+      "person_id": "richmond_shire_council/john_wharton",
+      "organization_id": "legislature/richmond_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "richmond_shire_council/bethea_pattel",
+      "organization_id": "legislature/richmond_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "richmond_shire_council/clay_kennedy",
+      "organization_id": "legislature/richmond_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "richmond_shire_council/june_kuhl",
+      "organization_id": "legislature/richmond_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "richmond_shire_council/kevin_bawden",
+      "organization_id": "legislature/richmond_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "richmond_shire_council/patsy-ann_fox",
+      "organization_id": "legislature/richmond_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "rockhampton_regional_council/margaret_strelow",
+      "organization_id": "legislature/rockhampton_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "rockhampton_regional_council/drew_wickerson",
+      "organization_id": "legislature/rockhampton_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/team_mcmillan"
+    },
+    {
+      "person_id": "rockhampton_regional_council/cherie_rutherford",
+      "organization_id": "legislature/rockhampton_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "rockhampton_regional_council/ellen_smith",
+      "organization_id": "legislature/rockhampton_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "rockhampton_regional_council/neil_fisher",
+      "organization_id": "legislature/rockhampton_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "rockhampton_regional_council/rose_swadling",
+      "organization_id": "legislature/rockhampton_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "rockhampton_regional_council/stephen_schwarten",
+      "organization_id": "legislature/rockhampton_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/team_mcmillan"
+    },
+    {
+      "person_id": "rockhampton_regional_council/tony_williams",
+      "organization_id": "legislature/rockhampton_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
       "person_id": "scenic_rim_regional_council/john_brent",
+      "organization_id": "legislature/scenic_rim_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "scenic_rim_regional_council/michael_enright",
       "organization_id": "legislature/scenic_rim_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
@@ -6627,7 +6880,19 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "somerset_regional_council/alan_bechly",
+      "person_id": "somerset_regional_council/bob_whalley",
+      "organization_id": "legislature/somerset_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "somerset_regional_council/cheryl_gaedtke",
+      "organization_id": "legislature/somerset_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "somerset_regional_council/sean_choat",
       "organization_id": "legislature/somerset_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
@@ -6645,18 +6910,6 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "somerset_regional_council/jim_madden",
-      "organization_id": "legislature/somerset_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "somerset_regional_council/kirsten_moriarty",
-      "organization_id": "legislature/somerset_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
       "person_id": "somerset_regional_council/michael_ogg",
       "organization_id": "legislature/somerset_regional_council",
       "role": "councillor",
@@ -6669,19 +6922,25 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "south_burnett_regional_council/barry_green",
+      "person_id": "south_burnett_regional_council/roz_frohloff",
       "organization_id": "legislature/south_burnett_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "south_burnett_regional_council/damien_tessmann",
+      "person_id": "south_burnett_regional_council/gavin_jones",
       "organization_id": "legislature/south_burnett_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "south_burnett_regional_council/debra_palmer",
+      "person_id": "south_burnett_regional_council/danita_potter",
+      "organization_id": "legislature/south_burnett_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "south_burnett_regional_council/terry_fleischfresser",
       "organization_id": "legislature/south_burnett_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
@@ -6693,43 +6952,43 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "south_burnett_regional_council/keith_campbell",
-      "organization_id": "legislature/south_burnett_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
       "person_id": "south_burnett_regional_council/ros_heit",
       "organization_id": "legislature/south_burnett_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "southern_downs_regional_council/peter_blundell",
+      "person_id": "southern_downs_regional_council/tracy_dobie",
+      "organization_id": "legislature/southern_downs_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "southern_downs_regional_council/sheryl_windle",
+      "organization_id": "legislature/southern_downs_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "southern_downs_regional_council/rod_kelly",
+      "organization_id": "legislature/southern_downs_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "southern_downs_regional_council/marika_mcnichol",
+      "organization_id": "legislature/southern_downs_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "southern_downs_regional_council/yve_stocks",
       "organization_id": "legislature/southern_downs_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
       "person_id": "southern_downs_regional_council/cameron_gow",
-      "organization_id": "legislature/southern_downs_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "southern_downs_regional_council/denise_ingram",
-      "organization_id": "legislature/southern_downs_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "southern_downs_regional_council/glyn_rees",
-      "organization_id": "legislature/southern_downs_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "southern_downs_regional_council/jamie_mackenzie",
       "organization_id": "legislature/southern_downs_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
@@ -6742,12 +7001,6 @@
     },
     {
       "person_id": "southern_downs_regional_council/neil_meiklejohn",
-      "organization_id": "legislature/southern_downs_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "southern_downs_regional_council/ross_bartley",
       "organization_id": "legislature/southern_downs_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
@@ -6825,6 +7078,66 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
+      "person_id": "tablelands_regional_council/joe_paronella",
+      "organization_id": "legislature/tablelands_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "tablelands_regional_council/kate_eden",
+      "organization_id": "legislature/tablelands_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "tablelands_regional_council/annette_haydon",
+      "organization_id": "legislature/tablelands_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "tablelands_regional_council/anthony_ball",
+      "organization_id": "legislature/tablelands_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "tablelands_regional_council/samantha_banks",
+      "organization_id": "legislature/tablelands_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "tablelands_regional_council/katrina_spies",
+      "organization_id": "legislature/tablelands_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "tablelands_regional_council/bronwyn_voyce",
+      "organization_id": "legislature/tablelands_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "toowoomba_regional_council/joe_ramia",
+      "organization_id": "legislature/toowoomba_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "toowoomba_regional_council/megan_o'hara_sullivan",
+      "organization_id": "legislature/toowoomba_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "toowoomba_regional_council/james_o'shea",
+      "organization_id": "legislature/toowoomba_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
       "person_id": "toowoomba_regional_council/paul_antonio",
       "organization_id": "legislature/toowoomba_regional_council",
       "role": "councillor",
@@ -6861,12 +7174,6 @@
       "on_behalf_of_id": "party/independent"
     },
     {
-      "person_id": "toowoomba_regional_council/john_gouldson",
-      "organization_id": "legislature/toowoomba_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/lnp"
-    },
-    {
       "person_id": "toowoomba_regional_council/mike_williams",
       "organization_id": "legislature/toowoomba_regional_council",
       "role": "councillor",
@@ -6879,19 +7186,217 @@
       "on_behalf_of_id": "party/lnp"
     },
     {
-      "person_id": "toowoomba_regional_council/roslyn_scotney",
-      "organization_id": "legislature/toowoomba_regional_council",
+      "person_id": "torres_shire_council/vonda_malone",
+      "organization_id": "legislature/torres_shire_council",
       "role": "councillor",
-      "on_behalf_of_id": "party/lnp"
+      "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "toowoomba_regional_council/sue_englart",
-      "organization_id": "legislature/toowoomba_regional_council",
+      "person_id": "torres_shire_council/gabriel_bani",
+      "organization_id": "legislature/torres_shire_council",
       "role": "councillor",
-      "on_behalf_of_id": "party/independent"
+      "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "western_downs_regional_council/raymond_brown",
+      "person_id": "torres_shire_council/thomas_loban",
+      "organization_id": "legislature/torres_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "torres_shire_council/john_abednego",
+      "organization_id": "legislature/torres_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "torres_shire_council/yen_loban",
+      "organization_id": "legislature/torres_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "torres_strait_island_regional_council/fred_gela",
+      "organization_id": "legislature/torres_strait_island_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "torres_strait_island_regional_council/torenzo_elisala",
+      "organization_id": "legislature/torres_strait_island_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "torres_strait_island_regional_council/nona_laurie",
+      "organization_id": "legislature/torres_strait_island_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "torres_strait_island_regional_council/john_levi",
+      "organization_id": "legislature/torres_strait_island_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "torres_strait_island_regional_council/clara_tamu",
+      "organization_id": "legislature/torres_strait_island_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "torres_strait_island_regional_council/francis_pearson",
+      "organization_id": "legislature/torres_strait_island_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "torres_strait_island_regional_council/fraser_nai",
+      "organization_id": "legislature/torres_strait_island_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "torres_strait_island_regional_council/patrick_thaiday",
+      "organization_id": "legislature/torres_strait_island_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "torres_strait_island_regional_council/bob_kaigey",
+      "organization_id": "legislature/torres_strait_island_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "torres_strait_island_regional_council/david_bosun",
+      "organization_id": "legislature/torres_strait_island_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "torres_strait_island_regional_council/dimas_toby",
+      "organization_id": "legislature/torres_strait_island_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "torres_strait_island_regional_council/getano_lui",
+      "organization_id": "legislature/torres_strait_island_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "torres_strait_island_regional_council/rocky_stephen",
+      "organization_id": "legislature/torres_strait_island_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "torres_strait_island_regional_council/keith_fell",
+      "organization_id": "legislature/torres_strait_island_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "torres_strait_island_regional_council/mario_sabatino",
+      "organization_id": "legislature/torres_strait_island_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "torres_strait_island_regional_council/ron_enosa",
+      "organization_id": "legislature/torres_strait_island_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "townsville_city_council/jenny_hill",
+      "organization_id": "legislature/townsville_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/team_jenny_hill"
+    },
+    {
+      "person_id": "townsville_city_council/margie_ryder",
+      "organization_id": "legislature/townsville_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/team_jenny_hill"
+    },
+    {
+      "person_id": "townsville_city_council/paul_jacob",
+      "organization_id": "legislature/townsville_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/team_jenny_hill"
+    },
+    {
+      "person_id": "townsville_city_council/ann-maree_greaney",
+      "organization_id": "legislature/townsville_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/team_jenny_hill"
+    },
+    {
+      "person_id": "townsville_city_council/mark_molachino",
+      "organization_id": "legislature/townsville_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/team_jenny_hill"
+    },
+    {
+      "person_id": "townsville_city_council/russ_cook",
+      "organization_id": "legislature/townsville_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/team_jenny_hill"
+    },
+    {
+      "person_id": "townsville_city_council/verena_coombe",
+      "organization_id": "legislature/townsville_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/team_jenny_hill"
+    },
+    {
+      "person_id": "townsville_city_council/kurt_rehbein",
+      "organization_id": "legislature/townsville_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/team_jenny_hill"
+    },
+    {
+      "person_id": "townsville_city_council/maurie_soars",
+      "organization_id": "legislature/townsville_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/team_jenny_hill"
+    },
+    {
+      "person_id": "townsville_city_council/colleen_doyle",
+      "organization_id": "legislature/townsville_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/team_jenny_hill"
+    },
+    {
+      "person_id": "townsville_city_council/les_walker",
+      "organization_id": "legislature/townsville_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/team_jenny_hill"
+    },
+    {
+      "person_id": "western_downs_regional_council/paul_mcveigh",
+      "organization_id": "legislature/western_downs_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "western_downs_regional_council/peter_saxelby",
+      "organization_id": "legislature/western_downs_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "western_downs_regional_council/kaye_maguire",
+      "organization_id": "legislature/western_downs_regional_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "western_downs_regional_council/donna_ashurst",
       "organization_id": "legislature/western_downs_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
@@ -6909,18 +7414,6 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "western_downs_regional_council/charlene_hall",
-      "organization_id": "legislature/western_downs_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
-      "person_id": "western_downs_regional_council/george_moore",
-      "organization_id": "legislature/western_downs_regional_council",
-      "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
-    },
-    {
       "person_id": "western_downs_regional_council/greg_olm",
       "organization_id": "legislature/western_downs_regional_council",
       "role": "councillor",
@@ -6933,103 +7426,191 @@
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "western_downs_regional_council/raymond_jamieson",
+      "person_id": "western_downs_regional_council/raymond_brown",
       "organization_id": "legislature/western_downs_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "western_downs_regional_council/tony_brame",
-      "organization_id": "legislature/western_downs_regional_council",
+      "person_id": "whitsunday_regional_council/andrew_willcox",
+      "organization_id": "legislature/whitsunday_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "livingstone_shire_council/bill_ludwig",
-      "organization_id": "legislature/livingstone_shire_council",
+      "person_id": "whitsunday_regional_council/ron_petterson",
+      "organization_id": "legislature/whitsunday_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "livingstone_shire_council/adam_belot",
-      "organization_id": "legislature/livingstone_shire_council",
+      "person_id": "whitsunday_regional_council/mike_brunker",
+      "organization_id": "legislature/whitsunday_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "livingstone_shire_council/glenda_mather",
-      "organization_id": "legislature/livingstone_shire_council",
+      "person_id": "whitsunday_regional_council/dave_clark",
+      "organization_id": "legislature/whitsunday_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "livingstone_shire_council/graham_scott",
-      "organization_id": "legislature/livingstone_shire_council",
+      "person_id": "whitsunday_regional_council/jan_clifford",
+      "organization_id": "legislature/whitsunday_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "livingstone_shire_council/jan_kelly",
-      "organization_id": "legislature/livingstone_shire_council",
+      "person_id": "whitsunday_regional_council/john_collins",
+      "organization_id": "legislature/whitsunday_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "livingstone_shire_council/nigel_hutton",
-      "organization_id": "legislature/livingstone_shire_council",
+      "person_id": "whitsunday_regional_council/peter_ramage",
+      "organization_id": "legislature/whitsunday_regional_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "livingstone_shire_council/tom_wyatt",
-      "organization_id": "legislature/livingstone_shire_council",
+      "person_id": "winton_shire_council/butch_lenton",
+      "organization_id": "legislature/winton_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "noosa_shire_council/noel_playford",
-      "organization_id": "legislature/noosa_shire_council",
+      "person_id": "winton_shire_council/joel_mann",
+      "organization_id": "legislature/winton_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "noosa_shire_council/bob_abbott",
-      "organization_id": "legislature/noosa_shire_council",
+      "person_id": "winton_shire_council/travis_harbour",
+      "organization_id": "legislature/winton_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "noosa_shire_council/frank_pardon",
-      "organization_id": "legislature/noosa_shire_council",
+      "person_id": "winton_shire_council/gavin_baskett",
+      "organization_id": "legislature/winton_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "noosa_shire_council/frank_wilkie",
-      "organization_id": "legislature/noosa_shire_council",
+      "person_id": "winton_shire_council/judy_sale",
+      "organization_id": "legislature/winton_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "noosa_shire_council/joe_jurisevic",
-      "organization_id": "legislature/noosa_shire_council",
+      "person_id": "winton_shire_council/shane_mann",
+      "organization_id": "legislature/winton_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "noosa_shire_council/sandy_bolton",
-      "organization_id": "legislature/noosa_shire_council",
+      "person_id": "woorabinda_aboriginal_shire_council/shane_wilkie",
+      "organization_id": "legislature/woorabinda_aboriginal_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "noosa_shire_council/tony_wellington",
-      "organization_id": "legislature/noosa_shire_council",
+      "person_id": "woorabinda_aboriginal_shire_council/stewart_smith",
+      "organization_id": "legislature/woorabinda_aboriginal_shire_council",
       "role": "councillor",
       "on_behalf_of_id": "party/unknown"
     },
     {
-      "person_id": "banana_shire_council/ron_carige",
+      "person_id": "woorabinda_aboriginal_shire_council/laurence_weazel",
+      "organization_id": "legislature/woorabinda_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "woorabinda_aboriginal_shire_council/phillip_alberts",
+      "organization_id": "legislature/woorabinda_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "woorabinda_aboriginal_shire_council/archie_williams",
+      "organization_id": "legislature/woorabinda_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "wujal_wujal_aboriginal_shire_council/clifford_harrigan",
+      "organization_id": "legislature/wujal_wujal_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "wujal_wujal_aboriginal_shire_council/robert_bloomfield",
+      "organization_id": "legislature/wujal_wujal_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "wujal_wujal_aboriginal_shire_council/bradley_creek",
+      "organization_id": "legislature/wujal_wujal_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "wujal_wujal_aboriginal_shire_council/bobby_kulka",
+      "organization_id": "legislature/wujal_wujal_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "wujal_wujal_aboriginal_shire_council/vincent_tayley",
+      "organization_id": "legislature/wujal_wujal_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "yarrabah_aboriginal_shire_council/ross_andrews",
+      "organization_id": "legislature/yarrabah_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "yarrabah_aboriginal_shire_council/nadine_cannon",
+      "organization_id": "legislature/yarrabah_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "yarrabah_aboriginal_shire_council/colin_cedric",
+      "organization_id": "legislature/yarrabah_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "yarrabah_aboriginal_shire_council/ian_patterson",
+      "organization_id": "legislature/yarrabah_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "yarrabah_aboriginal_shire_council/michael_sands",
+      "organization_id": "legislature/yarrabah_aboriginal_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown"
+    },
+    {
+      "person_id": "aurukun_shire_council/dereck_walpo",
+      "organization_id": "legislature/aurukun_shire_council",
+      "role": "mayor"
+    },
+    {
+      "person_id": "balonne_shire_council/richard_marsh",
+      "organization_id": "legislature/balonne_shire_council",
+      "role": "mayor"
+    },
+    {
+      "person_id": "banana_shire_council/nev_ferrier",
       "organization_id": "legislature/banana_shire_council",
       "role": "mayor"
     },
@@ -7039,7 +7620,7 @@
       "role": "mayor"
     },
     {
-      "person_id": "barcoo_shire_council/julie_groves",
+      "person_id": "barcoo_shire_council/bruce_scott",
       "organization_id": "legislature/barcoo_shire_council",
       "role": "mayor"
     },
@@ -7054,62 +7635,22 @@
       "role": "mayor"
     },
     {
-      "person_id": "central_highlands_regional_council/peter_maguire",
-      "organization_id": "legislature/central_highlands_regional_council",
+      "person_id": "brisbane_city_council/graham_quirk",
+      "organization_id": "legislature/brisbane_city_council",
       "role": "mayor"
     },
     {
-      "person_id": "diamantina_shire_council/geoff_morton",
-      "organization_id": "legislature/diamantina_shire_council",
+      "person_id": "bulloo_shire_council/john_ferguson",
+      "organization_id": "legislature/bulloo_shire_council",
       "role": "mayor"
     },
     {
-      "person_id": "gladstone_regional_council/gail_sellers",
-      "organization_id": "legislature/gladstone_regional_council",
+      "person_id": "bundaberg_regional_council/jack_dempsey",
+      "organization_id": "legislature/bundaberg_regional_council",
       "role": "mayor"
     },
     {
-      "person_id": "isaac_regional_council/anne_baker",
-      "organization_id": "legislature/isaac_regional_council",
-      "role": "mayor"
-    },
-    {
-      "person_id": "longreach_regional_council/joe_owens",
-      "organization_id": "legislature/longreach_regional_council",
-      "role": "mayor"
-    },
-    {
-      "person_id": "mackay_regional_council/deirdre_comerford",
-      "organization_id": "legislature/mackay_regional_council",
-      "role": "mayor"
-    },
-    {
-      "person_id": "rockhampton_regional_council/margaret_strelow",
-      "organization_id": "legislature/rockhampton_regional_council",
-      "role": "mayor"
-    },
-    {
-      "person_id": "whitsunday_regional_council/jennifer_(jenny)_whitney",
-      "organization_id": "legislature/whitsunday_regional_council",
-      "role": "mayor"
-    },
-    {
-      "person_id": "winton_shire_council/butch_lenton",
-      "organization_id": "legislature/winton_shire_council",
-      "role": "mayor"
-    },
-    {
-      "person_id": "woorabinda_aboriginal_shire_council/terry_munns",
-      "organization_id": "legislature/woorabinda_aboriginal_shire_council",
-      "role": "mayor"
-    },
-    {
-      "person_id": "aurukun_shire_council/dereck_walpo",
-      "organization_id": "legislature/aurukun_shire_council",
-      "role": "mayor"
-    },
-    {
-      "person_id": "burdekin_shire_council/bill_lowis",
+      "person_id": "burdekin_shire_council/lyn_mclaughlin",
       "organization_id": "legislature/burdekin_shire_council",
       "role": "mayor"
     },
@@ -7119,22 +7660,37 @@
       "role": "mayor"
     },
     {
-      "person_id": "cairns_regional_council/bob_manning_oam",
+      "person_id": "cairns_regional_council/bob_manning",
       "organization_id": "legislature/cairns_regional_council",
       "role": "mayor"
     },
     {
-      "person_id": "carpentaria_shire_council/fred_pascoe",
+      "person_id": "carpentaria_shire_council/lyall_(jack)_bawden",
       "organization_id": "legislature/carpentaria_shire_council",
       "role": "mayor"
     },
     {
-      "person_id": "charters_towers_regional_council/franklin_beveridge",
+      "person_id": "cassowary_coast_regional_council/john_kremastos",
+      "organization_id": "legislature/cassowary_coast_regional_council",
+      "role": "mayor"
+    },
+    {
+      "person_id": "central_highlands_regional_council/kerry_hayes",
+      "organization_id": "legislature/central_highlands_regional_council",
+      "role": "mayor"
+    },
+    {
+      "person_id": "charters_towers_regional_council/liz_schmidt",
       "organization_id": "legislature/charters_towers_regional_council",
       "role": "mayor"
     },
     {
-      "person_id": "cloncurry_shire_council/andrew_daniels",
+      "person_id": "cherbourg_aboriginal_shire_council/kenny_bone",
+      "organization_id": "legislature/cherbourg_aboriginal_shire_council",
+      "role": "mayor"
+    },
+    {
+      "person_id": "cloncurry_shire_council/gregory_campbell",
       "organization_id": "legislature/cloncurry_shire_council",
       "role": "mayor"
     },
@@ -7149,143 +7705,38 @@
       "role": "mayor"
     },
     {
-      "person_id": "doomadgee_aboriginal_shire_council/frederick_o'keefe",
+      "person_id": "diamantina_shire_council/geoff_morton",
+      "organization_id": "legislature/diamantina_shire_council",
+      "role": "mayor"
+    },
+    {
+      "person_id": "doomadgee_aboriginal_shire_council/edric_walden",
       "organization_id": "legislature/doomadgee_aboriginal_shire_council",
       "role": "mayor"
     },
     {
-      "person_id": "etheridge_shire_council/will_attwood",
+      "person_id": "douglas_shire_council/julia_leu",
+      "organization_id": "legislature/douglas_shire_council",
+      "role": "mayor"
+    },
+    {
+      "person_id": "etheridge_shire_council/warren_devlin",
       "organization_id": "legislature/etheridge_shire_council",
       "role": "mayor"
     },
     {
-      "person_id": "flinders_shire_council/greg_jones",
+      "person_id": "flinders_shire_council/jane_mcnamara",
       "organization_id": "legislature/flinders_shire_council",
       "role": "mayor"
     },
     {
-      "person_id": "hinchinbrook_shire_council/mansell_(rodger)_bow",
-      "organization_id": "legislature/hinchinbrook_shire_council",
-      "role": "mayor"
-    },
-    {
-      "person_id": "kowanyama_aboriginal_shire_council/robert_holness",
-      "organization_id": "legislature/kowanyama_aboriginal_shire_council",
-      "role": "mayor"
-    },
-    {
-      "person_id": "lockhart_river_aboriginal_shire_council/wayne_butcher",
-      "organization_id": "legislature/lockhart_river_aboriginal_shire_council",
-      "role": "mayor"
-    },
-    {
-      "person_id": "mapoon_aboriginal_shire_council/peter_guivarra",
-      "organization_id": "legislature/mapoon_aboriginal_shire_council",
-      "role": "mayor"
-    },
-    {
-      "person_id": "mckinlay_shire_council/belinda_murphy",
-      "organization_id": "legislature/mckinlay_shire_council",
-      "role": "mayor"
-    },
-    {
-      "person_id": "mornington_shire_council/bradley_wilson",
-      "organization_id": "legislature/mornington_shire_council",
-      "role": "mayor"
-    },
-    {
-      "person_id": "mount_isa_city_council/tony_mcgrady",
-      "organization_id": "legislature/mount_isa_city_council",
-      "role": "mayor"
-    },
-    {
-      "person_id": "napranum_aboriginal_shire_council/philemon_mene",
-      "organization_id": "legislature/napranum_aboriginal_shire_council",
-      "role": "mayor"
-    },
-    {
-      "person_id": "northern_peninsula_area_regional_council/bernard_charlie",
-      "organization_id": "legislature/northern_peninsula_area_regional_council",
-      "role": "mayor"
-    },
-    {
-      "person_id": "palm_island_aboriginal_shire_council/alfred_lacey",
-      "organization_id": "legislature/palm_island_aboriginal_shire_council",
-      "role": "mayor"
-    },
-    {
-      "person_id": "pormpuraaw_aboriginal_shire_council/richard_tarpencha",
-      "organization_id": "legislature/pormpuraaw_aboriginal_shire_council",
-      "role": "mayor"
-    },
-    {
-      "person_id": "richmond_shire_council/john_wharton",
-      "organization_id": "legislature/richmond_shire_council",
-      "role": "mayor"
-    },
-    {
-      "person_id": "tablelands_regional_council/rosa_lee_long",
-      "organization_id": "legislature/tablelands_regional_council",
-      "role": "mayor"
-    },
-    {
-      "person_id": "torres_strait_island_regional_council/fred_gela",
-      "organization_id": "legislature/torres_strait_island_regional_council",
-      "role": "mayor"
-    },
-    {
-      "person_id": "townsville_city_council/jenny_hill",
-      "organization_id": "legislature/townsville_city_council",
-      "role": "Mayor"
-    },
-    {
-      "person_id": "townsville_city_council/les_walker",
-      "organization_id": "legislature/townsville_city_council",
-      "role": "Deputy Mayor"
-    },
-    {
-      "person_id": "wujal_wujal_aboriginal_shire_council/clifford_harrigan",
-      "organization_id": "legislature/wujal_wujal_aboriginal_shire_council",
-      "role": "mayor"
-    },
-    {
-      "person_id": "yarrabah_aboriginal_shire_council/errol_neal",
-      "organization_id": "legislature/yarrabah_aboriginal_shire_council",
-      "role": "mayor"
-    },
-    {
-      "person_id": "mareeba_shire_council/tom_gilmore",
-      "organization_id": "legislature/mareeba_shire_council",
-      "role": "mayor"
-    },
-    {
-      "person_id": "balonne_shire_council/donna_stewart",
-      "organization_id": "legislature/balonne_shire_council",
-      "role": "mayor"
-    },
-    {
-      "person_id": "brisbane_city_council/graham_quirk",
-      "organization_id": "legislature/brisbane_city_council",
-      "role": "mayor"
-    },
-    {
-      "person_id": "bulloo_shire_council/john_ferguson",
-      "organization_id": "legislature/bulloo_shire_council",
-      "role": "mayor"
-    },
-    {
-      "person_id": "bundaberg_regional_council/mal_forman",
-      "organization_id": "legislature/bundaberg_regional_council",
-      "role": "mayor"
-    },
-    {
-      "person_id": "cherbourg_aboriginal_shire_council/kenny_bone",
-      "organization_id": "legislature/cherbourg_aboriginal_shire_council",
-      "role": "mayor"
-    },
-    {
-      "person_id": "fraser_coast_regional_council/gerard_o'connell",
+      "person_id": "fraser_coast_regional_council/chris_loft",
       "organization_id": "legislature/fraser_coast_regional_council",
+      "role": "mayor"
+    },
+    {
+      "person_id": "gladstone_regional_council/matt_burnett",
+      "organization_id": "legislature/gladstone_regional_council",
       "role": "mayor"
     },
     {
@@ -7299,8 +7750,43 @@
       "role": "mayor"
     },
     {
+      "person_id": "gympie_regional_council/mick_curran",
+      "organization_id": "legislature/gympie_regional_council",
+      "role": "mayor"
+    },
+    {
+      "person_id": "hinchinbrook_shire_council/ramon_jayo",
+      "organization_id": "legislature/hinchinbrook_shire_council",
+      "role": "mayor"
+    },
+    {
+      "person_id": "hope_vale_aboriginal_shire_council/greg_mclean",
+      "organization_id": "legislature/hope_vale_aboriginal_shire_council",
+      "role": "mayor"
+    },
+    {
       "person_id": "ipswich_city_council/paul_pisasale",
       "organization_id": "legislature/ipswich_city_council",
+      "role": "mayor"
+    },
+    {
+      "person_id": "isaac_regional_council/anne_baker",
+      "organization_id": "legislature/isaac_regional_council",
+      "role": "mayor"
+    },
+    {
+      "person_id": "kowanyama_aboriginal_shire_council/michael_yam",
+      "organization_id": "legislature/kowanyama_aboriginal_shire_council",
+      "role": "mayor"
+    },
+    {
+      "person_id": "livingstone_shire_council/bill_ludwig",
+      "organization_id": "legislature/livingstone_shire_council",
+      "role": "mayor"
+    },
+    {
+      "person_id": "lockhart_river_aboriginal_shire_council/wayne_butcher",
+      "organization_id": "legislature/lockhart_river_aboriginal_shire_council",
       "role": "mayor"
     },
     {
@@ -7309,18 +7795,38 @@
       "role": "mayor"
     },
     {
-      "person_id": "logan_city_council/cherie_dalley",
-      "organization_id": "legislature/logan_city_council",
-      "role": "Deputy Mayor"
-    },
-    {
       "person_id": "logan_city_council/luke_smith",
       "organization_id": "legislature/logan_city_council",
-      "role": "Mayor"
+      "role": "mayor"
     },
     {
-      "person_id": "maranoa_regional_council/robert_loughnan",
+      "person_id": "longreach_regional_council/joe_owens",
+      "organization_id": "legislature/longreach_regional_council",
+      "role": "mayor"
+    },
+    {
+      "person_id": "mackay_regional_council/greg_williamson",
+      "organization_id": "legislature/mackay_regional_council",
+      "role": "mayor"
+    },
+    {
+      "person_id": "mapoon_aboriginal_shire_council/aileen_addo",
+      "organization_id": "legislature/mapoon_aboriginal_shire_council",
+      "role": "mayor"
+    },
+    {
+      "person_id": "maranoa_regional_council/tyson_golder",
       "organization_id": "legislature/maranoa_regional_council",
+      "role": "mayor"
+    },
+    {
+      "person_id": "mareeba_shire_council/tom_gilmore",
+      "organization_id": "legislature/mareeba_shire_council",
+      "role": "mayor"
+    },
+    {
+      "person_id": "mckinlay_shire_council/belinda_murphy",
+      "organization_id": "legislature/mckinlay_shire_council",
       "role": "mayor"
     },
     {
@@ -7329,8 +7835,28 @@
       "role": "mayor"
     },
     {
-      "person_id": "murweh_shire_council/denis_cook",
+      "person_id": "mornington_shire_council/bradley_wilson",
+      "organization_id": "legislature/mornington_shire_council",
+      "role": "mayor"
+    },
+    {
+      "person_id": "mount_isa_city_council/joyce_mcculloch",
+      "organization_id": "legislature/mount_isa_city_council",
+      "role": "mayor"
+    },
+    {
+      "person_id": "murweh_shire_council/anne_maree_liston",
       "organization_id": "legislature/murweh_shire_council",
+      "role": "mayor"
+    },
+    {
+      "person_id": "napranum_aboriginal_shire_council/rex_burke",
+      "organization_id": "legislature/napranum_aboriginal_shire_council",
+      "role": "mayor"
+    },
+    {
+      "person_id": "noosa_shire_council/tony_wellington",
+      "organization_id": "legislature/noosa_shire_council",
       "role": "mayor"
     },
     {
@@ -7339,8 +7865,23 @@
       "role": "mayor"
     },
     {
+      "person_id": "northern_peninsula_area_regional_council/edward_newman",
+      "organization_id": "legislature/northern_peninsula_area_regional_council",
+      "role": "mayor"
+    },
+    {
+      "person_id": "palm_island_aboriginal_shire_council/alfred_lacey",
+      "organization_id": "legislature/palm_island_aboriginal_shire_council",
+      "role": "mayor"
+    },
+    {
       "person_id": "paroo_shire_council/lindsay_godfrey",
       "organization_id": "legislature/paroo_shire_council",
+      "role": "mayor"
+    },
+    {
+      "person_id": "pormpuraaw_aboriginal_shire_council/",
+      "organization_id": "legislature/pormpuraaw_aboriginal_shire_council",
       "role": "mayor"
     },
     {
@@ -7351,6 +7892,16 @@
     {
       "person_id": "redland_city_council/karen_williams",
       "organization_id": "legislature/redland_city_council",
+      "role": "mayor"
+    },
+    {
+      "person_id": "richmond_shire_council/john_wharton",
+      "organization_id": "legislature/richmond_shire_council",
+      "role": "mayor"
+    },
+    {
+      "person_id": "rockhampton_regional_council/margaret_strelow",
+      "organization_id": "legislature/rockhampton_regional_council",
       "role": "mayor"
     },
     {
@@ -7369,7 +7920,7 @@
       "role": "mayor"
     },
     {
-      "person_id": "southern_downs_regional_council/peter_blundell",
+      "person_id": "southern_downs_regional_council/tracy_dobie",
       "organization_id": "legislature/southern_downs_regional_council",
       "role": "mayor"
     },
@@ -7379,23 +7930,58 @@
       "role": "mayor"
     },
     {
+      "person_id": "tablelands_regional_council/joe_paronella",
+      "organization_id": "legislature/tablelands_regional_council",
+      "role": "mayor"
+    },
+    {
       "person_id": "toowoomba_regional_council/paul_antonio",
       "organization_id": "legislature/toowoomba_regional_council",
       "role": "mayor"
     },
     {
-      "person_id": "western_downs_regional_council/raymond_brown",
+      "person_id": "torres_shire_council/vonda_malone",
+      "organization_id": "legislature/torres_shire_council",
+      "role": "mayor"
+    },
+    {
+      "person_id": "torres_strait_island_regional_council/fred_gela",
+      "organization_id": "legislature/torres_strait_island_regional_council",
+      "role": "mayor"
+    },
+    {
+      "person_id": "townsville_city_council/jenny_hill",
+      "organization_id": "legislature/townsville_city_council",
+      "role": "mayor"
+    },
+    {
+      "person_id": "western_downs_regional_council/paul_mcveigh",
       "organization_id": "legislature/western_downs_regional_council",
       "role": "mayor"
     },
     {
-      "person_id": "livingstone_shire_council/bill_ludwig",
-      "organization_id": "legislature/livingstone_shire_council",
+      "person_id": "whitsunday_regional_council/andrew_willcox",
+      "organization_id": "legislature/whitsunday_regional_council",
       "role": "mayor"
     },
     {
-      "person_id": "noosa_shire_council/noel_playford",
-      "organization_id": "legislature/noosa_shire_council",
+      "person_id": "winton_shire_council/butch_lenton",
+      "organization_id": "legislature/winton_shire_council",
+      "role": "mayor"
+    },
+    {
+      "person_id": "woorabinda_aboriginal_shire_council/shane_wilkie",
+      "organization_id": "legislature/woorabinda_aboriginal_shire_council",
+      "role": "mayor"
+    },
+    {
+      "person_id": "wujal_wujal_aboriginal_shire_council/clifford_harrigan",
+      "organization_id": "legislature/wujal_wujal_aboriginal_shire_council",
+      "role": "mayor"
+    },
+    {
+      "person_id": "yarrabah_aboriginal_shire_council/ross_andrews",
+      "organization_id": "legislature/yarrabah_aboriginal_shire_council",
       "role": "mayor"
     }
   ],


### PR DESCRIPTION
This adds and removes councillors to update the sheet with scraped results
of QLD March Local Elections elections.

Every single councillor appears in this diff, because their order in the
file changed.

It also fills in data for councillors from:

* Bundaberg Regional Council
* Cairns Regional Council
* Fraser Coast Regional Council
* Mackay Regional Council
* Redland city council
* Rockhampton Regional Council

Thanks @archoo for collecting all this data!