### PR TITLE
updated Ballarat City Council data for issue #97

### DIFF
--- a/vic_local_councillor_popolo.json
+++ b/vic_local_councillor_popolo.json
@@ -189,6 +189,22 @@
       ]
     },
     {
+      "email": "markharris@ballarat.vic.gov.au",
+      "id": "ballarat_city_council/mark_harris",
+      "image": "http://www.ballarat.vic.gov.au/media/4120099/mark_harris.jpg",
+      "name": "Mark Harris",
+      "images": [
+        {
+          "url": "http://www.ballarat.vic.gov.au/media/4120099/mark_harris.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.ballarat.vic.gov.au/ac/councillors-and-wards/meet-your-councillors/councillor-mark-harris.aspx"
+        }
+      ]
+    },
+    {
       "email": "vickicoltman@ballarat.vic.gov.au",
       "id": "ballarat_city_council/vicki_coltman",
       "image": "http://www.ballarat.vic.gov.au/media/982735/cr_vicki_coltman.jpg",
@@ -237,6 +253,38 @@
       ]
     },
     {
+      "email": "granttillett@ballarat.vic.gov.au",
+      "id": "ballarat_city_council/grant_tillett",
+      "image": "http://www.ballarat.vic.gov.au/media/4120165/grant_tillett.jpg",
+      "name": "Grant Tillett",
+      "images": [
+        {
+          "url": "http://www.ballarat.vic.gov.au/media/4120165/grant_tillett.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.ballarat.vic.gov.au/ac/councillors-and-wards/meet-your-councillors/councillor-grant-tillett.aspx"
+        }
+      ]
+    },
+    {
+      "email": "danielmoloney@ballarat.vic.gov.au",
+      "id": "ballarat_city_council/daniel_moloney",
+      "image": "http://www.ballarat.vic.gov.au/media/4120154/daniel_moloney.jpg",
+      "name": "Daniel Moloney",
+      "images": [
+        {
+          "url": "http://www.ballarat.vic.gov.au/media/4120154/daniel_moloney.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.ballarat.vic.gov.au/ac/councillors-and-wards/meet-your-councillors/councillor-daniel-moloney.aspx"
+        }
+      ]
+    },
+    {
       "email": "DesHudson@ballarat.vic.gov.au",
       "id": "ballarat_city_council/des_hudson",
       "image": "http://www.ballarat.vic.gov.au/media/982740/cr_des_hudson.jpg",
@@ -281,6 +329,22 @@
       "sources": [
         {
           "url": "http://www.ballarat.vic.gov.au/ac/councillors-and-wards.aspx"
+        }
+      ]
+    },
+    {
+      "email": "bentaylor@ballarat.vic.gov.au",
+      "id": "ballarat_city_council/ben_taylor",
+      "image": "http://www.ballarat.vic.gov.au/media/4120110/ben_taylor.jpg",
+      "name": "Ben Taylor",
+      "images": [
+        {
+          "url": "http://www.ballarat.vic.gov.au/media/4120110/ben_taylor.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.ballarat.vic.gov.au/ac/councillors-and-wards/meet-your-councillors/councillor-ben-taylor.aspx"
         }
       ]
     },
@@ -1831,6 +1895,22 @@
       ]
     },
     {
+      "email": "jackson.taylor@knox.vic.gov.au",
+      "id": "knox_city_council/jackson_taylor",
+      "image": "https://www.knox.vic.gov.au/Page/Images/2016_Cr_Jackson_Taylor.jpg",
+      "name": "Jackson Taylor",
+      "images": [
+        {
+          "url": "https://www.knox.vic.gov.au/Page/Images/2016_Cr_Jackson_Taylor.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "https://www.knox.vic.gov.au/Page/Page.aspx?Page_Id=109"
+        }
+      ]
+    },
+    {
       "email": "adam.gill@knox.vic.gov.au",
       "id": "knox_city_council/adam_gill",
       "image": "http://www.knox.vic.gov.au/Page/Images/cr_adam_gill_2012.jpg",
@@ -1859,6 +1939,22 @@
       "sources": [
         {
           "url": "http://www.knox.vic.gov.au/Page/Page.aspx?Page_Id=111"
+        }
+      ]
+    },
+    {
+      "email": "Jake.Keorg@knox.vic.gov.au",
+      "id": "knox_city_council/jake_keorg",
+      "image": "https://www.knox.vic.gov.au/Page/Images/2016_Cr_Jake_Keogh.jpg",
+      "name": "Jake Keorg",
+      "images": [
+        {
+          "url": "https://www.knox.vic.gov.au/Page/Images/2016_Cr_Jake_Keogh.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "https://www.knox.vic.gov.au/Page/Page.aspx?Page_Id=109"
         }
       ]
     },
@@ -3903,6 +3999,22 @@
       ]
     },
     {
+      "email": "Danae.Bosler@yarracity.vic.gov.au",
+      "id": "yarra_city_council/danae_bolser",
+      "image": "http://yarracity.vic.gov.au/IgnitionSuite/uploads/images/Danae%20Bosler.jpg",
+      "name": "Danae Bosler",
+      "images": [
+        {
+          "url": "http://yarracity.vic.gov.au/IgnitionSuite/uploads/images/Danae%20Bosler.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://yarracity.vic.gov.au/Your-Council/Councillors/cr-danae-bosler/"
+        }
+      ]
+    },
+    {
       "email": "Misha.Coleman@yarracity.vic.gov.au",
       "id": "yarra_city_council/misha_coleman",
       "image": "http://www.yarracity.vic.gov.au/IgnitionSuite/uploads/images/Cr-Misha-Coleman.jpg",
@@ -3951,6 +4063,54 @@
       ]
     },
     {
+      "email": "Daniel.Nguyen@yarracity.vic.gov.au",
+      "id": "yarra_city_council/daniel_nguyen",
+      "image": "http://www.yarracity.vic.gov.au/IgnitionSuite/uploads/images/Daniel%20Nguyen.jpg",
+      "name": "Daniel Nguyen",
+      "images": [
+        {
+          "url": "http://www.yarracity.vic.gov.au/IgnitionSuite/uploads/images/Daniel%20Nguyen.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.yarracity.vic.gov.au/Your-Council/Councillors/cr-daniel-nguyen/"
+        }
+      ]
+    },
+    {
+      "email": "Milin.Chenyimei@yarracity.vic.gov.au ",
+      "id": "yarra_city_council/min-lin_chen_yi_mei",
+      "image": "http://www.yarracity.vic.gov.au/IgnitionSuite/uploads/images/Mi%20Lin%20Chen%20Yi%20Mei.jpg",
+      "name": "Mi-Lin Chen Yi Mei",
+      "images": [
+        {
+          "url": "http://www.yarracity.vic.gov.au/IgnitionSuite/uploads/images/Mi%20Lin%20Chen%20Yi%20Mei.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.yarracity.vic.gov.au/Your-Council/Councillors/mi-lin-chen-yi-mei/"
+        }
+      ]
+    },
+    {
+      "email": "James.Searle@yarracity.vic.gov.au",
+      "id": "yarra_city_council/james_searle",
+      "image": "http://yarracity.vic.gov.au/IgnitionSuite/uploads/images/James%20Searle.jpg",
+      "name": "James Searle",
+      "images": [
+        {
+          "url": "http://yarracity.vic.gov.au/IgnitionSuite/uploads/images/James%20Searle.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://yarracity.vic.gov.au/your-council/councillors/cr-james-searle/"
+        }
+      ]
+    },
+    {
       "email": "mayor@yarracity.vic.gov.au",
       "id": "yarra_city_council/roberto_colanzi",
       "image": "http://www.yarracity.vic.gov.au/IgnitionSuite/uploads/images/Cr-Roberto-Colanzi2012_7.jpg",
@@ -3995,6 +4155,22 @@
       "sources": [
         {
           "url": "http://www.yarracity.vic.gov.au/Your-Council/Councillors/Sam-Gaylard/"
+        }
+      ]
+    },
+    {
+      "email": "Mike.McEvoy@yarracity.vic.gov.au",
+      "id": "yarra_city_council/mike_mcevoy",
+      "image": "http://yarracity.vic.gov.au/IgnitionSuite/uploads/images/Mike%20McEvoy.jpg",
+      "name": "Mike McEvoy",
+      "images": [
+        {
+          "url": "http://yarracity.vic.gov.au/IgnitionSuite/uploads/images/Mike%20McEvoy.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://yarracity.vic.gov.au/Your-Council/Councillors/cr-mike-mcevoy/"
         }
       ]
     },
@@ -4049,11 +4225,11 @@
     {
       "email": "CrMikeClarke@yarraranges.vic.gov.au",
       "id": "yarra_ranges_shire_council/mike_clarke",
-      "image": "http://www.yarraranges.vic.gov.au/files/assets/public/images/system-images/councillor-photos/mike-clarke.png",
+      "image": "https://www.yarraranges.vic.gov.au/files/assets/public/images/system-images/councillor-photos/2016/mike-clarke-2016-130px.jpg",
       "name": "Mike Clarke",
       "images": [
         {
-          "url": "http://www.yarraranges.vic.gov.au/files/assets/public/images/system-images/councillor-photos/mike-clarke.png"
+          "url": "https://www.yarraranges.vic.gov.au/files/assets/public/images/system-images/councillor-photos/2016/mike-clarke-2016-130px.jpg"
         }
       ],
       "sources": [
@@ -4065,11 +4241,11 @@
     {
       "email": "CrTerryAvery@yarraranges.vic.gov.au",
       "id": "yarra_ranges_shire_council/terry_avery",
-      "image": "http://www.yarraranges.vic.gov.au/files/assets/public/images/system-images/councillor-photos/terry-avery-melba-web.jpg",
+      "image": "https://www.yarraranges.vic.gov.au/files/assets/public/images/system-images/councillor-photos/2016/terry-avery-2016-130px.jpg",
       "name": "Terry Avery",
       "images": [
         {
-          "url": "http://www.yarraranges.vic.gov.au/files/assets/public/images/system-images/councillor-photos/terry-avery-melba-web.jpg"
+          "url": "https://www.yarraranges.vic.gov.au/files/assets/public/images/system-images/councillor-photos/2016/terry-avery-2016-130px.jpg"
         }
       ],
       "sources": [
@@ -4081,11 +4257,11 @@
     {
       "email": "CrJimChild@yarraranges.vic.gov.au",
       "id": "yarra_ranges_shire_council/jim_child",
-      "image": "http://www.yarraranges.vic.gov.au/files/assets/public/images/system-images/councillor-photos/jim-child-oshannassy-web.jpg",
+      "image": "https://www.yarraranges.vic.gov.au/files/assets/public/images/system-images/councillor-photos/2016/jim-child-2016-130px.jpg",
       "name": "Jim Child",
       "images": [
         {
-          "url": "http://www.yarraranges.vic.gov.au/files/assets/public/images/system-images/councillor-photos/jim-child-oshannassy-web.jpg"
+          "url": "https://www.yarraranges.vic.gov.au/files/assets/public/images/system-images/councillor-photos/2016/jim-child-2016-130px.jpg"
         }
       ],
       "sources": [
@@ -4097,11 +4273,11 @@
     {
       "email": "CrFionaMcAllister@yarraranges.vic.gov.au",
       "id": "yarra_ranges_shire_council/fiona_mcallister",
-      "image": "http://www.yarraranges.vic.gov.au/files/assets/public/images/system-images/councillor-photos/fiona-mcallister-ryrie-web.jpg",
+      "image": "https://www.yarraranges.vic.gov.au/files/assets/public/images/system-images/councillor-photos/2016/fiona-mcallister-2016-130px.jpg",
       "name": "Fiona McAllister",
       "images": [
         {
-          "url": "http://www.yarraranges.vic.gov.au/files/assets/public/images/system-images/councillor-photos/fiona-mcallister-ryrie-web.jpg"
+          "url": "https://www.yarraranges.vic.gov.au/files/assets/public/images/system-images/councillor-photos/2016/fiona-mcallister-2016-130px.jpg"
         }
       ],
       "sources": [
@@ -4113,11 +4289,11 @@
     {
       "email": "CrNoelCliff@yarraranges.vic.gov.au",
       "id": "yarra_ranges_shire_council/noel_cliff",
-      "image": "http://www.yarraranges.vic.gov.au/files/assets/public/images/system-images/councillor-photos/noel-cliff-streeton-web.jpg",
+      "image": "https://www.yarraranges.vic.gov.au/files/assets/public/images/system-images/councillor-photos/2016/noel-cliff-2016-130px_1.jpg",
       "name": "Noel Cliff",
       "images": [
         {
-          "url": "http://www.yarraranges.vic.gov.au/files/assets/public/images/system-images/councillor-photos/noel-cliff-streeton-web.jpg"
+          "url": "https://www.yarraranges.vic.gov.au/files/assets/public/images/system-images/councillor-photos/2016/noel-cliff-2016-130px_1.jpg"
         }
       ],
       "sources": [
@@ -4129,16 +4305,64 @@
     {
       "email": "CrLenCox@yarraranges.vic.gov.au",
       "id": "yarra_ranges_shire_council/len_cox",
-      "image": "http://www.yarraranges.vic.gov.au/files/assets/public/images/system-images/councillor-photos/len-cox-walling-web.jpg",
+      "image": "https://www.yarraranges.vic.gov.au/files/assets/public/images/system-images/councillor-photos/2016/len-cox-2016-130px.jpg",
       "name": "Len Cox",
       "images": [
         {
-          "url": "http://www.yarraranges.vic.gov.au/files/assets/public/images/system-images/councillor-photos/len-cox-walling-web.jpg"
+          "url": "https://www.yarraranges.vic.gov.au/files/assets/public/images/system-images/councillor-photos/2016/len-cox-2016-130px.jpg"
         }
       ],
       "sources": [
         {
           "url": "http://www.yarraranges.vic.gov.au/Lists/Councillors/Cr-Len-Cox"
+        }
+      ]
+    },
+    {
+      "email": "CrTimHeenan@yarraranges.vic.gov.au",
+      "id": "yarra_ranges_shire_council/tim_heenan",
+      "image": "https://www.yarraranges.vic.gov.au/files/assets/public/images/system-images/councillor-photos/2016/tim-heenan-2016-130px.jpg",
+      "name": "Tim Heenan",
+      "images": [
+        {
+          "url": "https://www.yarraranges.vic.gov.au/files/assets/public/images/system-images/councillor-photos/2016/tim-heenan-2016-130px.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "https://www.yarraranges.vic.gov.au/Lists/Councillors/Cr-Tim-Heenan"
+        }
+      ]
+    },
+    {
+      "email": "CrTonyStevenson@yarraranges.vic.gov.au",
+      "id": "yarra_ranges_shire_council/tony_stevenson",
+      "image": "https://www.yarraranges.vic.gov.au/files/assets/public/images/system-images/councillor-photos/2016/tony-stevenson-2016-130px.jpg",
+      "name": "Tony Stevenson",
+      "images": [
+        {
+          "url": "https://www.yarraranges.vic.gov.au/files/assets/public/images/system-images/councillor-photos/2016/tony-stevenson-2016-130px.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "https://www.yarraranges.vic.gov.au/Lists/Councillors/Cr-Tony-Stevenson"
+        }
+      ]
+    },
+    {
+      "email": "CrRichardHiggine@yarraranges.vic.gov.au",
+      "id": "yarra_ranges_shire_council/richard_higgins",
+      "image": "https://www.yarraranges.vic.gov.au/files/assets/public/images/system-images/councillor-photos/2016/richard-higgins-2016-130px.jpg",
+      "name": "Richard Higgins",
+      "images": [
+        {
+          "url": "https://www.yarraranges.vic.gov.au/files/assets/public/images/system-images/councillor-photos/2016/richard-higgins-2016-130px.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "https://www.yarraranges.vic.gov.au/Lists/Councillors/Cr-Richard-Higgins"
         }
       ]
     },
@@ -4752,7 +4976,8 @@
       "person_id": "ballarat_city_council/glen_crompton",
       "organization_id": "legislature/ballarat_city_council",
       "role": "councillor",
-      "on_behalf_of_id": "party/independent"
+      "on_behalf_of_id": "party/independent",
+      "end_date": "2016-10-22"
     },
     {
       "person_id": "ballarat_city_council/belinda_coates",
@@ -4767,10 +4992,18 @@
       "on_behalf_of_id": "party/liberal"
     },
     {
+      "person_id": "ballarat_city_council/mark_harris",
+      "organization_id": "legislature/ballarat_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/independent",
+      "start_date": "2016-10-23"
+    },
+    {
       "person_id": "ballarat_city_council/vicki_coltman",
       "organization_id": "legislature/ballarat_city_council",
       "role": "councillor",
-      "on_behalf_of_id": "party/liberal"
+      "on_behalf_of_id": "party/liberal",
+      "end_date": "2016-10-22"
     },
     {
       "person_id": "ballarat_city_council/amy_johnson",
@@ -4782,7 +5015,22 @@
       "person_id": "ballarat_city_council/john_philips",
       "organization_id": "legislature/ballarat_city_council",
       "role": "councillor",
-      "on_behalf_of_id": "party/independent"
+      "on_behalf_of_id": "party/independent",
+      "end_date": "2016-10-22"
+    },
+    {
+      "person_id": "ballarat_city_council/grant_tillett",
+      "organization_id": "legislature/ballarat_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown",
+      "start_date": "2016-10-23"
+    },
+    {
+      "person_id": "ballarat_city_council/daniel_moloney",
+      "organization_id": "legislature/ballarat_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown",
+      "start_date": "2016-10-23"
     },
     {
       "person_id": "ballarat_city_council/des_hudson",
@@ -4794,13 +5042,21 @@
       "person_id": "ballarat_city_council/peter_innes",
       "organization_id": "legislature/ballarat_city_council",
       "role": "councillor",
-      "on_behalf_of_id": "party/independent"
+      "on_behalf_of_id": "party/independent",
+      "end_date": "2016-10-22"
     },
     {
       "person_id": "ballarat_city_council/jim_rinaldi",
       "organization_id": "legislature/ballarat_city_council",
       "role": "councillor",
       "on_behalf_of_id": "party/independent"
+    },
+    {
+      "person_id": "ballarat_city_council/ben_taylor",
+      "organization_id": "legislature/ballarat_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/liberal",
+      "start_date": "2016-10-23"
     },
     {
       "person_id": "banyule_city_council/mark_di_pasquale",
@@ -6374,7 +6630,15 @@
       "person_id": "knox_city_council/joe_cossari",
       "organization_id": "legislature/knox_city_council",
       "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
+      "on_behalf_of_id": "party/unknown",
+      "end_date": "2016-10-22"
+    },
+    {
+      "person_id": "knox_city_council/jackson_taylor",
+      "organization_id": "legislature/knox_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/independent",
+      "start_date": "2016-10-23"
     },
     {
       "person_id": "knox_city_council/adam_gill",
@@ -6386,7 +6650,15 @@
       "person_id": "knox_city_council/karin_orpen",
       "organization_id": "legislature/knox_city_council",
       "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
+      "on_behalf_of_id": "party/independent",
+      "end_date": "2016-10-22"
+    },
+    {
+      "person_id": "knox_city_council/jake_keorg",
+      "organization_id": "legislature/knox_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/unknown",
+      "start_date": "2016-10-23"
     },
     {
       "person_id": "knox_city_council/tony_holland",
@@ -6398,7 +6670,8 @@
       "person_id": "knox_city_council/lisa_cooper",
       "organization_id": "legislature/knox_city_council",
       "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
+      "on_behalf_of_id": "party/unknown",
+      "end_date": "2016-10-22"
     },
     {
       "person_id": "knox_city_council/darren_pearce",
@@ -8360,7 +8633,8 @@
       "person_id": "yarra_city_council/geoff_barbour",
       "organization_id": "legislature/yarra_city_council",
       "role": "councillor",
-      "on_behalf_of_id": "party/australian_labor_party"
+      "on_behalf_of_id": "party/australian_labor_party",
+      "end_date": "2016-10-22"
     },
     {
       "person_id": "yarra_city_council/stephen_jolly",
@@ -8375,6 +8649,13 @@
       "on_behalf_of_id": "party/victorian_greens"
     },
     {
+      "person_id": "yarra_city_council/danae_bolser",
+      "organization_id": "legislature/yarra_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/australian_labor_party",
+      "start_date": "2016-10-23"
+    },
+    {
       "person_id": "yarra_city_council/misha_coleman",
       "organization_id": "legislature/yarra_city_council",
       "role": "councillor",
@@ -8384,19 +8665,43 @@
       "person_id": "yarra_city_council/simon_huggins",
       "organization_id": "legislature/yarra_city_council",
       "role": "councillor",
-      "on_behalf_of_id": "party/australian_labor_party"
+      "on_behalf_of_id": "party/australian_labor_party",
+      "end_date": "2016-10-22"
     },
     {
       "person_id": "yarra_city_council/phillip_vlahogiannis",
       "organization_id": "legislature/yarra_city_council",
       "role": "councillor",
-      "on_behalf_of_id": "party/independent"
+      "on_behalf_of_id": "party/independent",
+      "end_date": "2016-10-22"
+    },
+    {
+      "person_id": "yarra_city_council/daniel_nguyen",
+      "organization_id": "legislature/yarra_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/independent",
+      "start_date": "2016-10-23"
+    },
+    {
+      "person_id": "yarra_city_council/min-lin_chen_yi_mei",
+      "organization_id": "legislature/yarra_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/australian_labor_party",
+      "start_date": "2016-10-23"
+    },
+    {
+      "person_id": "yarra_city_council/james_searle",
+      "organization_id": "legislature/yarra_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/victorian_greens",
+      "start_date": "2016-10-23"
     },
     {
       "person_id": "yarra_city_council/roberto_colanzi",
       "organization_id": "legislature/yarra_city_council",
       "role": "councillor",
-      "on_behalf_of_id": "party/australian_labor_party"
+      "on_behalf_of_id": "party/australian_labor_party",
+      "end_date": "2016-10-22"
     },
     {
       "person_id": "yarra_city_council/jackie_fristacky",
@@ -8408,61 +8713,93 @@
       "person_id": "yarra_city_council/sam_gaylard",
       "organization_id": "legislature/yarra_city_council",
       "role": "councillor",
-      "on_behalf_of_id": "party/victorian_greens"
+      "on_behalf_of_id": "party/victorian_greens",
+      "end_date": "2016-10-22"
+    },
+    {
+      "person_id": "yarra_city_council/mike_mcevoy",
+      "organization_id": "legislature/yarra_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/victorian_greens",
+      "start_date": "2016-10-23"
     },
     {
       "person_id": "yarra_ranges_shire_council/maria_mccarthy",
       "organization_id": "legislature/yarra_ranges_shire_council",
       "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
+      "on_behalf_of_id": "party/independent",
+      "end_date": "2016-10-22"
     },
     {
       "person_id": "yarra_ranges_shire_council/jason_callanan",
       "organization_id": "legislature/yarra_ranges_shire_council",
       "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
+      "on_behalf_of_id": "party/independent",
+      "end_date": "2016-10-22"
     },
     {
       "person_id": "yarra_ranges_shire_council/andy_witlox",
       "organization_id": "legislature/yarra_ranges_shire_council",
       "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
+      "on_behalf_of_id": "party/independent",
+      "end_date": "2016-10-22"
     },
     {
       "person_id": "yarra_ranges_shire_council/mike_clarke",
       "organization_id": "legislature/yarra_ranges_shire_council",
       "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
+      "on_behalf_of_id": "party/independent"
     },
     {
       "person_id": "yarra_ranges_shire_council/terry_avery",
       "organization_id": "legislature/yarra_ranges_shire_council",
       "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
+      "on_behalf_of_id": "party/independent"
     },
     {
       "person_id": "yarra_ranges_shire_council/jim_child",
       "organization_id": "legislature/yarra_ranges_shire_council",
       "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
+      "on_behalf_of_id": "party/independent"
     },
     {
       "person_id": "yarra_ranges_shire_council/fiona_mcallister",
       "organization_id": "legislature/yarra_ranges_shire_council",
       "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
+      "on_behalf_of_id": "party/independent"
     },
     {
       "person_id": "yarra_ranges_shire_council/noel_cliff",
       "organization_id": "legislature/yarra_ranges_shire_council",
       "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
+      "on_behalf_of_id": "party/independent"
     },
     {
       "person_id": "yarra_ranges_shire_council/len_cox",
       "organization_id": "legislature/yarra_ranges_shire_council",
       "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
+      "on_behalf_of_id": "party/independent"
+    },
+    {
+      "person_id": "yarra_ranges_shire_council/tim_heenan",
+      "organization_id": "legislature/yarra_ranges_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/independent",
+      "start_date": "2016-10-23"
+    },
+    {
+      "person_id": "yarra_ranges_shire_council/tony_stevenson",
+      "organization_id": "legislature/yarra_ranges_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/independent",
+      "start_date": "2016-10-23"
+    },
+    {
+      "person_id": "yarra_ranges_shire_council/richard_higgins",
+      "organization_id": "legislature/yarra_ranges_shire_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/independent",
+      "start_date": "2016-10-23"
     },
     {
       "person_id": "yarriambiack_shire_council/terry_grange",
@@ -8518,6 +8855,11 @@
     },
     {
       "person_id": "ballarat_city_council/belinda_coates",
+      "organization_id": "legislature/ballarat_city_council",
+      "role": "Deputy Mayor"
+    },
+    {
+      "person_id": "ballarat_city_council/mark_harris",
       "organization_id": "legislature/ballarat_city_council",
       "role": "Deputy Mayor"
     },
@@ -8912,9 +9254,14 @@
       "role": "mayor"
     },
     {
-      "person_id": "yarra_ranges_shire_council/jason_callanan",
+      "person_id": "yarra_ranges_shire_council/noel_cliff",
       "organization_id": "legislature/yarra_ranges_shire_council",
       "role": "mayor"
+    },
+    {
+      "person_id": "yarra_ranges_shire_council/len_cox",
+      "organization_id": "legislature/yarra_ranges_shire_council",
+      "role": "deputy mayor"
     },
     {
       "person_id": "yarriambiack_shire_council/ray_kingston",


### PR DESCRIPTION
updated Ballarat City Council data for <a href="https://github.com/openaustralia/australian_local_councillors_popolo/issues/97">issue #97</a>

new:
- Mark Harris(Central)
- Grant Tillett(North)
- Daniel Moloney(North)
- Ben Taylor(South)

end_date added:
- Glen Crompton(Central)
- Vicki Coltman(North)
-  John Philips(North)
- Peter Innes(South)