### PR TITLE
Updated the rake task to fetch local csv instead of google spread sheet

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,27 +1,13 @@
-require "tempfile"
-require "open-uri"
-require "json"
-require "csv_to_popolo"
+require_relative "lib/councillor_popolo"
 
 STATES = ["act","nsw", "nt", "qld", "sa", "tas", "vic", "wa"]
-
-def update_data(state)
-  json_filename = "#{state.to_s}_local_councillor_popolo.json"
-  csv_filename = "data/#{state.upcase}/#{state}_local_councillors.csv"
-
-  puts "Fetching #{state.to_s.upcase} CSV: #{csv_filename}"
-  file = File.read(csv_filename)
-  json = JSON.pretty_generate(Popolo::CSV.new(csv_filename).data)
-  puts "Saving: #{json_filename}"
-  File.open(json_filename, "w") { |f| f << json }
-end
 
 task default: [:update_all]
 
 desc "Update data from CSV files in data folder for all states"
 task :update_all do
   STATES.each do |state|
-    update_data(state)
+    CouncillorPopolo.update_data(state)
   end
 end
 
@@ -29,5 +15,5 @@ desc "Update data from CSV files in data folder for a specific state: #{STATES.j
 task :update, [:state] do |t, args|
   state = args.state.to_sym
 
-  update_data(state)
+  CouncillorPopolo.update_data(state)
 end

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ task default: [:update_all]
 desc "Update data from CSV files in data folder for all states"
 task :update_all do
   STATES.each do |state|
-    CouncillorPopolo.update_data(state)
+    CouncillorPopolo.update_popolo_for_state(state)
   end
 end
 
@@ -15,5 +15,5 @@ desc "Update data from CSV files in data folder for a specific state: #{STATES.j
 task :update, [:state] do |t, args|
   state = args.state.to_sym
 
-  CouncillorPopolo.update_data(state)
+  CouncillorPopolo.update_popolo_for_state(state)
 end

--- a/lib/councillor_popolo.rb
+++ b/lib/councillor_popolo.rb
@@ -4,7 +4,7 @@ require "json"
 require "csv_to_popolo"
 
 class CouncillorPopolo
-  def self.update_data(state)
+  def self.update_popolo_for_state(state)
     json_filename = "#{state.to_s}_local_councillor_popolo.json"
     csv_filename = "data/#{state.upcase}/#{state}_local_councillors.csv"
 

--- a/lib/councillor_popolo.rb
+++ b/lib/councillor_popolo.rb
@@ -1,0 +1,17 @@
+require "tempfile"
+require "open-uri"
+require "json"
+require "csv_to_popolo"
+
+class CouncillorPopolo
+  def self.update_data(state)
+    json_filename = "#{state.to_s}_local_councillor_popolo.json"
+    csv_filename = "data/#{state.upcase}/#{state}_local_councillors.csv"
+
+    puts "Fetching #{state.to_s.upcase} CSV: #{csv_filename}"
+    file = File.read(csv_filename)
+    json = JSON.pretty_generate(Popolo::CSV.new(csv_filename).data)
+    puts "Saving: #{json_filename}"
+    File.open(json_filename, "w") { |f| f << json }
+  end
+end

--- a/nsw_local_councillor_popolo.json
+++ b/nsw_local_councillor_popolo.json
@@ -22715,8 +22715,8 @@
   "warnings": {
     "skipped": [
       "council_website",
-      "phone_mobile",
-      "ward"
+      "ward",
+      "phone_mobile"
     ]
   }
 }

--- a/vic_local_councillor_popolo.json
+++ b/vic_local_councillor_popolo.json
@@ -3882,12 +3882,36 @@
       "name": "John Chandler"
     },
     {
+      "email": "jklisaris@stonnington.vic.gov.au",
       "id": "stonnington_city_council/jami_klisaris",
-      "name": "Jami Klisaris"
+      "image": "http://www.stonnington.vic.gov.au/files/assets/public/council/councillors/jami-klisaris-mayoral-robes.jpg",
+      "name": "Jami Klisaris",
+      "images": [
+        {
+          "url": "http://www.stonnington.vic.gov.au/files/assets/public/council/councillors/jami-klisaris-mayoral-robes.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.stonnington.vic.gov.au/Council/The-Mayor-and-Councillors/Mayor-Cr-Jami-Klisaris"
+        }
+      ]
     },
     {
+      "email": "mkoce@stonnington.vic.gov.au",
       "id": "stonnington_city_council/matthew_koce",
-      "name": "Matthew Koce"
+      "image": "http://www.stonnington.vic.gov.au/files/assets/public/council/councillors/mathew-koce_4839-crop.jpg",
+      "name": "Matthew Koce",
+      "images": [
+        {
+          "url": "http://www.stonnington.vic.gov.au/files/assets/public/council/councillors/mathew-koce_4839-crop.jpg"
+        }
+      ],
+      "sources": [
+        {
+          "url": "http://www.stonnington.vic.gov.au/Council/The-Mayor-and-Councillors/Cr-Matthew-Koce"
+        }
+      ]
     },
     {
       "id": "stonnington_city_council/haritini_athanasopoulos",
@@ -8480,25 +8504,29 @@
       "person_id": "stonnington_city_council/erin_davie",
       "organization_id": "legislature/stonnington_city_council",
       "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
+      "on_behalf_of_id": "party/unknown",
+      "end_date": "2016-11-02"
     },
     {
       "person_id": "stonnington_city_council/john_mcmorrow",
       "organization_id": "legislature/stonnington_city_council",
       "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
+      "on_behalf_of_id": "party/unknown",
+      "end_date": "2016-11-02"
     },
     {
       "person_id": "stonnington_city_council/jimi_athanasopoulos",
       "organization_id": "legislature/stonnington_city_council",
       "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
+      "on_behalf_of_id": "party/unknown",
+      "end_date": "2016-11-02"
     },
     {
       "person_id": "stonnington_city_council/john_chandler",
       "organization_id": "legislature/stonnington_city_council",
       "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
+      "on_behalf_of_id": "party/unknown",
+      "end_date": "2016-11-02"
     },
     {
       "person_id": "stonnington_city_council/jami_klisaris",
@@ -8516,7 +8544,8 @@
       "person_id": "stonnington_city_council/haritini_athanasopoulos",
       "organization_id": "legislature/stonnington_city_council",
       "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
+      "on_behalf_of_id": "party/unknown",
+      "end_date": "2016-11-02"
     },
     {
       "person_id": "stonnington_city_council/melina_sehr",
@@ -8528,7 +8557,8 @@
       "person_id": "stonnington_city_council/claude_ullin",
       "organization_id": "legislature/stonnington_city_council",
       "role": "councillor",
-      "on_behalf_of_id": "party/unknown"
+      "on_behalf_of_id": "party/unknown",
+      "end_date": "2016-11-02"
     },
     {
       "person_id": "strathbogie_shire_council/patrick_storer",
@@ -9615,7 +9645,7 @@
       "role": "mayor"
     },
     {
-      "person_id": "stonnington_city_council/claude_ullin",
+      "person_id": "stonnington_city_council/jami_klisaris",
       "organization_id": "legislature/stonnington_city_council",
       "role": "mayor"
     },

--- a/vic_local_councillor_popolo.json
+++ b/vic_local_councillor_popolo.json
@@ -9172,7 +9172,15 @@
       "person_id": "yarra_city_council/sam_gaylard",
       "organization_id": "legislature/yarra_city_council",
       "role": "councillor",
-      "on_behalf_of_id": "party/victorian_greens"
+      "on_behalf_of_id": "party/victorian_greens",
+      "end_date": "2016-10-22"
+    },
+    {
+      "person_id": "yarra_city_council/mike_mcevoy",
+      "organization_id": "legislature/yarra_city_council",
+      "role": "councillor",
+      "on_behalf_of_id": "party/victorian_greens",
+      "start_date": "2016-10-23"
     },
     {
       "person_id": "yarra_ranges_shire_council/maria_mccarthy",


### PR DESCRIPTION
*** PR #124 should be merged before this PR***

This is a part of #95.

In this PR, I updated rake task to fetch councillor data from local csv files in data folder instead of google spread sheet. 
Rake task will abort without csv files in data folder so please merge#124 before this. As I mentioned in #124, In a few csv files, there were special charactors that keep aborting rake tasks, such as å and û.
I changed them into a and u, as it is unnecessary troubles for contributors.