### PR TITLE
[WIP] Add a morph.io scraper to collect new councillor data contributions from PlanningAlerts

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -1,0 +1,19 @@
+# get the contributions from the PlanningAlerts Contributions API
+# e.g https://www.planningalerts.org.au/councillor_contributions.json
+#
+# for each contribution
+#
+# git checkout a new branch based on the contribution id. Maybe use shell out http://shiroyasha.io/running-shell-commands-from-ruby.html ?
+#
+# Merge the changes (with the rake task? bundle exec rake update_state_from_remote_csv[vic,https://www.planningalerts.org.au/authorities/glen_eira/councillor_contributions/5.csv] )
+#
+# if there are changes to the ./data directory
+#   stage them
+#
+#   Commit the changes
+#
+#   Open/ReOpen a PR from the new branch with some useful info, like the contributor's
+#   name and the source of the information.
+#
+# TODO: This process could also manage updates to the Crontribution and add
+#       commits to the contribution branch/PR


### PR DESCRIPTION
This scraper would turn contributions of councillor data from PlanningAlerts into Pull Requests to this repo.

I've started this off with some pseudo code for how I think this could work https://github.com/openaustralia/australian_local_councillors_popolo/compare/planningalerts_scraper?expand=1#diff-4fa627201df14a294b00abb2a0d97fb0

What do ya think?

Note the TODO on the end, I don't think the first running PR of this needs to include that behavior, so don't worry about that for this PR.

This is part of https://github.com/openaustralia/planningalerts/issues/1203

@hisayohorie feel free to jump in here and see what you think :D 

Remember not to commit any Github credentials or keys if they get added, but use dotenv or something for that :D That's a nasty mistake I've made before!